### PR TITLE
Add rutor & thepiratebay for torrent results

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -218,4 +218,4 @@ def search():
 
 
 if __name__ == "__main__":
-    app.run(threaded=True, port=PORT)
+    app.run(threaded=True, port=PORT, debug=True)

--- a/__init__.py
+++ b/__init__.py
@@ -218,4 +218,4 @@ def search():
 
 
 if __name__ == "__main__":
-    app.run(threaded=True, port=PORT, debug=True)
+    app.run(threaded=True, port=PORT)

--- a/_config.py
+++ b/_config.py
@@ -79,6 +79,14 @@ ENABLED_TORRENT_SITES = [
     "rutor",
 ]
 
+TORRENT_TRACKERS = [
+    'http://nyaa.tracker.wf:7777/announce',
+    'udp://open.stealth.si:80/announce',
+    'udp://tracker.opentrackr.org:1337/announce',
+    'udp://exodus.desync.com:6969/announce',
+    'udp://tracker.torrent.eu.org:451/announce'
+]
+
 COOKIE_AGE = 2147483647
 
 # set to true to enable api support

--- a/_config.py
+++ b/_config.py
@@ -74,9 +74,9 @@ WHITELISTED_DOMAINS = [
 
 ENABLED_TORRENT_SITES = [
     "nyaa",
-    "torrentgalaxy",
-    "tpb",
-    "rutor",
+    # "torrentgalaxy",
+    # "tpb",
+    # "rutor",
 ]
 
 COOKIE_AGE = 2147483647

--- a/_config.py
+++ b/_config.py
@@ -20,6 +20,7 @@ TORRENTGALAXY_DOMAIN = "torrentgalaxy.to"
 NYAA_DOMAIN = "nyaa.si"
 # apibay is the api for thepiratebay.org
 API_BAY_DOMAIN = "apibay.org"
+RUTOR_DOMAIN = "rutor.info"
 
 # Domain of the Invidious instance to use
 INVIDIOUS_INSTANCE = "yt.artemislena.eu"
@@ -68,12 +69,14 @@ WHITELISTED_DOMAINS = [
     TORRENTGALAXY_DOMAIN,
     NYAA_DOMAIN,
     API_BAY_DOMAIN,
+    RUTOR_DOMAIN,
 ]
 
 ENABLED_TORRENT_SITES = [
     "nyaa",
     "torrentgalaxy",
-    "tpd"
+    "tpb",
+    "rutor"
 ]
 
 COOKIE_AGE = 2147483647

--- a/_config.py
+++ b/_config.py
@@ -76,7 +76,7 @@ ENABLED_TORRENT_SITES = [
     "nyaa",
     "torrentgalaxy",
     "tpb",
-    "rutor"
+    "rutor",
 ]
 
 COOKIE_AGE = 2147483647

--- a/_config.py
+++ b/_config.py
@@ -18,6 +18,8 @@ PORT = 8000
 # Torrent domains
 TORRENTGALAXY_DOMAIN = "torrentgalaxy.to"
 NYAA_DOMAIN = "nyaa.si"
+# apibay is the api for thepiratebay.org
+API_BAY_DOMAIN = "apibay.org"
 
 # Domain of the Invidious instance to use
 INVIDIOUS_INSTANCE = "yt.artemislena.eu"
@@ -65,11 +67,13 @@ WHITELISTED_DOMAINS = [
     "lite.qwant.com",
     TORRENTGALAXY_DOMAIN,
     NYAA_DOMAIN,
+    API_BAY_DOMAIN,
 ]
 
 ENABLED_TORRENT_SITES = [
     "nyaa",
     "torrentgalaxy",
+    "tpd"
 ]
 
 COOKIE_AGE = 2147483647

--- a/_config.py
+++ b/_config.py
@@ -74,9 +74,9 @@ WHITELISTED_DOMAINS = [
 
 ENABLED_TORRENT_SITES = [
     "nyaa",
-    # "torrentgalaxy",
-    # "tpb",
-    # "rutor",
+    "torrentgalaxy",
+    "tpb",
+    "rutor",
 ]
 
 COOKIE_AGE = 2147483647

--- a/src/helpers.py
+++ b/src/helpers.py
@@ -58,7 +58,7 @@ def makeJSONRequest(url: str):
     # Choose a user-agent at random
     user_agent = random.choice(user_agents)
     headers = {"User-Agent": user_agent}
-    # Grab HTML content
+    # Grab json content
     response = requests.get(url)
 
     # Return the JSON object

--- a/src/helpers.py
+++ b/src/helpers.py
@@ -63,3 +63,17 @@ def makeJSONRequest(url: str):
 
     # Return the JSON object
     return json.loads(response.text)
+
+def get_magnet_hash(magnet):
+    return magnet.split("btih:")[1].split("&")[0]
+
+def get_magnet_name(magnet):
+    return magnet.split("&dn=")[1].split("&tr")[0]
+
+
+def apply_trackers(hash, name="", magnet=True):
+    if magnet:
+        name = get_magnet_name(hash)
+        hash = get_magnet_hash(hash)
+    
+    return f"magnet:?xt=urn:btih:{hash}&dn={name}&tr={'&tr='.join(TORRENT_TRACKERS)}"

--- a/src/helpers.py
+++ b/src/helpers.py
@@ -1,10 +1,11 @@
-from bs4 import BeautifulSoup
-from urllib.parse import unquote
 import random
-from _config import *
-from markupsafe import escape, Markup
 import requests
 import re
+import json
+from bs4 import BeautifulSoup
+from urllib.parse import unquote
+from _config import *
+from markupsafe import escape, Markup
 from os.path import exists
 
 
@@ -46,3 +47,19 @@ def latest_commit():
         with open('./.git/refs/heads/main') as f:
             return f.readline()
     return "Not in main branch"
+
+
+def makeHTMLRequest(url: str):
+    # block unwanted request from an edited cookie
+    domain = unquote(url).split('/')[2]
+    if domain not in WHITELISTED_DOMAINS:
+        raise Exception(f"The domain '{domain}' is not whitelisted.")
+
+    # Choose a user-agent at random
+    user_agent = random.choice(user_agents)
+    headers = {"User-Agent": user_agent}
+    # Grab HTML content
+    response = requests.get(url)
+
+    # Return the BeautifulSoup object
+    return json.loads(response.content)

--- a/src/helpers.py
+++ b/src/helpers.py
@@ -49,7 +49,7 @@ def latest_commit():
     return "Not in main branch"
 
 
-def makeHTMLRequest(url: str):
+def makeJSONRequest(url: str):
     # block unwanted request from an edited cookie
     domain = unquote(url).split('/')[2]
     if domain not in WHITELISTED_DOMAINS:
@@ -61,5 +61,5 @@ def makeHTMLRequest(url: str):
     # Grab HTML content
     response = requests.get(url)
 
-    # Return the BeautifulSoup object
-    return json.loads(response.content)
+    # Return the JSON object
+    return json.loads(response.text)

--- a/src/torrent_sites/nyaa.py
+++ b/src/torrent_sites/nyaa.py
@@ -9,15 +9,16 @@ def search(query):
     soup = helpers.makeHTMLRequest(f"https://{NYAA_DOMAIN}/?f=0&c=0_0&q={quote(query)}")
     results = []
     for torrent in soup.select(".default, .success, .danger"):
-        list_of_anchors = torrent.select("a")
-        text_center = torrent.select(".text-center")
+        # list_of_anchors = torrent.select("a")
+        # text_center = torrent.select(".text-center")
+        list_of_tds = torrent.find_all("td")
         results.append({
             "href": NYAA_DOMAIN,
-            "title": list_of_anchors[1].get_text().strip(),
-            "magnet": list_of_anchors[1]["href"],
-            "size": text_center[1].get_text().strip(),
+            "title": list_of_tds[1].find_all("a")[-1].get_text(),
+            "magnet": list_of_tds[2].find_all("a")[1]["href"],
+            "size": list_of_tds[3].get_text().strip(),
             "views": None,
-            "seeders": int(text_center[3].get_text().strip()),
-            "leechers": int(text_center[4].get_text().strip())
+            "seeders": int(list_of_tds[5].get_text().strip()),
+            "leechers": int(list_of_tds[6].get_text().strip())
         })
     return results

--- a/src/torrent_sites/nyaa.py
+++ b/src/torrent_sites/nyaa.py
@@ -9,8 +9,6 @@ def search(query):
     soup = helpers.makeHTMLRequest(f"https://{NYAA_DOMAIN}/?f=0&c=0_0&q={quote(query)}")
     results = []
     for torrent in soup.select(".default, .success, .danger"):
-        # list_of_anchors = torrent.select("a")
-        # text_center = torrent.select(".text-center")
         list_of_tds = torrent.find_all("td")
         results.append({
             "href": NYAA_DOMAIN,

--- a/src/torrent_sites/nyaa.py
+++ b/src/torrent_sites/nyaa.py
@@ -13,7 +13,7 @@ def search(query):
         results.append({
             "href": NYAA_DOMAIN,
             "title": list_of_tds[1].find_all("a")[-1].get_text(),
-            "magnet": helpers.apply_trackers(list_of_tds[2].find_all("a")[1]["href"]),
+            "magnet": helpers.apply_trackers(list_of_tds[2].find_all("a")[-1]["href"]),
             "size": list_of_tds[3].get_text().strip(),
             "views": None,
             "seeders": int(list_of_tds[5].get_text().strip()),

--- a/src/torrent_sites/nyaa.py
+++ b/src/torrent_sites/nyaa.py
@@ -13,7 +13,7 @@ def search(query):
         results.append({
             "href": NYAA_DOMAIN,
             "title": list_of_tds[1].find_all("a")[-1].get_text(),
-            "magnet": list_of_tds[2].find_all("a")[1]["href"],
+            "magnet": helpers.apply_trackers(list_of_tds[2].find_all("a")[1]["href"]),
             "size": list_of_tds[3].get_text().strip(),
             "views": None,
             "seeders": int(list_of_tds[5].get_text().strip()),

--- a/src/torrent_sites/rutor.py
+++ b/src/torrent_sites/rutor.py
@@ -9,10 +9,11 @@ def search(query):
     url = f"https://{RUTOR_DOMAIN}/search/{quote(query)}"
     html = helpers.makeHTMLRequest(url)
     results = []
-    
+
     for torrent in html.select(".gai, .tum"):
         tds = torrent.findall("td")
-        
+        spans = torrent.findall("span")
+
         # If a torrent has comments, it has 5 columns, but if it has none,
         # it has 4 columns. This is a shift to account for that.
         td_shift = len(tds) - 4
@@ -23,8 +24,8 @@ def search(query):
             "magnet": tds[1].findall("a")[1]["href"],
             "size": tds[2 + td_shift].get_text(),
             "views": None,
-            "seeders": int(tds[3 + td_shift].find("span", {"class": "green"}).get_text()),
-            "leechers": int(tds[3 + td_shift].find("span", {"class": "green"}).get_text()),
+            "seeders": int(spans[0].get_text()),
+            "leechers": int(spans[1]).get_text()),
         })
 
     return results

--- a/src/torrent_sites/rutor.py
+++ b/src/torrent_sites/rutor.py
@@ -15,10 +15,7 @@ def search(query):
         
         # If a torrent has comments, it has 5 columns, but if it has none,
         # it has 4 columns. This is a shift to account for that.
-        if len(tds) == 5:
-            td_shift = 1
-        else:
-            td_shift = 0
+        td_shift = len(tds) - 4
 
         results.append({
             "href": RUTOR_DOMAIN,

--- a/src/torrent_sites/rutor.py
+++ b/src/torrent_sites/rutor.py
@@ -25,7 +25,7 @@ def search(query):
             "size": tds[2 + td_shift].get_text(),
             "views": None,
             "seeders": int(spans[0].get_text()),
-            "leechers": int(spans[1]).get_text()),
+            "leechers": int(spans[1].get_text()),
         })
 
     return results

--- a/src/torrent_sites/rutor.py
+++ b/src/torrent_sites/rutor.py
@@ -11,18 +11,14 @@ def search(query):
     results = []
 
     for torrent in html.select(".gai, .tum"):
-        tds = torrent.findall("td")
-        spans = torrent.findall("span")
-
-        # If a torrent has comments, it has 5 columns, but if it has none,
-        # it has 4 columns. This is a shift to account for that.
-        td_shift = len(tds) - 4
+        tds = torrent.find_all("td")
+        spans = torrent.find_all("span")
 
         results.append({
             "href": RUTOR_DOMAIN,
             "title": tds[1].get_text(),
-            "magnet": tds[1].findall("a")[1]["href"],
-            "size": tds[2 + td_shift].get_text(),
+            "magnet": tds[1].find_all("a")[1]["href"],
+            "size": tds[-2].get_text(),
             "views": None,
             "seeders": int(spans[0].get_text()),
             "leechers": int(spans[1].get_text()),

--- a/src/torrent_sites/rutor.py
+++ b/src/torrent_sites/rutor.py
@@ -1,0 +1,33 @@
+from _config import *
+from src import helpers
+from urllib.parse import quote
+
+def name():
+    return "rutor"
+
+def search(query):
+    url = f"https://{RUTOR_DOMAIN}/search/{quote(query)}"
+    html = helpers.makeHTMLRequest(url)
+    results = []
+    
+    for torrent in html.select(".gai, .tum"):
+        tds = torrent.findall("td")
+        
+        # If a torrent has comments, it has 5 columns, but if it has none,
+        # it has 4 columns. This is a shift to account for that.
+        if len(tds) == 5:
+            td_shift = 1
+        else:
+            td_shift = 0
+
+        results.append({
+            "href": RUTOR_DOMAIN,
+            "title": tds[1].get_text(),
+            "magnet": tds[1].findall("a")[1]["href"],
+            "size": tds[2 + td_shift].get_text(),
+            "views": None,
+            "seeders": int(tds[3 + td_shift].find("span", {"class": "green"}).get_text()),
+            "leechers": int(tds[3 + td_shift].find("span", {"class": "green"}).get_text()),
+        })
+
+    return results

--- a/src/torrent_sites/rutor.py
+++ b/src/torrent_sites/rutor.py
@@ -17,7 +17,7 @@ def search(query):
         results.append({
             "href": RUTOR_DOMAIN,
             "title": tds[1].get_text(),
-            "magnet": tds[1].find_all("a")[1]["href"],
+            "magnet": helpers.apply_trackers(tds[1].find_all("a")[1]["href"]),
             "size": tds[-2].get_text(),
             "views": None,
             "seeders": int(spans[0].get_text()),

--- a/src/torrent_sites/thepiratebay.py
+++ b/src/torrent_sites/thepiratebay.py
@@ -1,0 +1,42 @@
+from _config import *
+from src import helpers
+from urllib.parse import quote
+
+def name():
+    return "tpb"
+
+def generate_magnet_link(info_hash):
+    return f"magnet:?xt=urn:btih:{info_hash}&tr=http://nyaa.tracker.wf:7777/announce&tr=udp://open.stealth.si:80/announce&tr=udp://tracker.opentrackr.org:1337/announce&tr=udp://exodus.desync.com:6969/announce&tr=udp://tracker.torrent.eu.org:451/announce"
+
+def convert_bytes(size):
+    units = ['bytes', 'KB', 'MB', 'GB', 'TB']
+    index = 0
+    while size >= 1024 and index < len(units) - 1:
+        size /= 1024
+        index += 1
+    return f"{size:.2f} {units[index]}"
+
+def search(query):
+    url = f"https://{API_BAY_DOMAIN}/q.php?q={quote(query)}&cat="
+    torrent_data = helpers.makeHTMLRequest(url)
+    results = []
+
+    for torrent in torrent_data:
+        try:
+            seeders = int(torrent["seeders"])
+            leechers = int(torrent["leechers"])
+        except ValueError:
+            seeders = 0
+            leechers = 0
+
+        results.append({
+            "href": "thepiratebay.org",
+            "title": torrent["name"],
+            "magnet": generate_magnet_link(torrent["info_hash"]),
+            "size": convert_bytes(int(torrent["size"])),
+            "views": None,
+            "seeders": seeders,
+            "leechers": leechers
+        })
+
+    return results

--- a/src/torrent_sites/thepiratebay.py
+++ b/src/torrent_sites/thepiratebay.py
@@ -5,9 +5,6 @@ from urllib.parse import quote
 def name():
     return "tpb"
 
-def generate_magnet_link(info_hash):
-    return f"magnet:?xt=urn:btih:{info_hash}&tr=http://nyaa.tracker.wf:7777/announce&tr=udp://open.stealth.si:80/announce&tr=udp://tracker.opentrackr.org:1337/announce&tr=udp://exodus.desync.com:6969/announce&tr=udp://tracker.torrent.eu.org:451/announce"
-
 def convert_bytes(size):
     units = ['bytes', 'KB', 'MB', 'GB', 'TB']
     index = 0
@@ -25,7 +22,11 @@ def search(query):
         results.append({
             "href": "thepiratebay.org",
             "title": torrent["name"],
-            "magnet": generate_magnet_link(torrent["info_hash"]),
+            "magnet": helpers.apply_trackers(
+                torrent["info_hash"],
+                name=torrent["name"],
+                magnet=False
+            ),
             "size": convert_bytes(int(torrent["size"])),
             "views": None,
             "seeders": int(torrent["seeders"]),

--- a/src/torrent_sites/thepiratebay.py
+++ b/src/torrent_sites/thepiratebay.py
@@ -22,21 +22,14 @@ def search(query):
     results = []
 
     for torrent in torrent_data:
-        try:
-            seeders = int(torrent["seeders"])
-            leechers = int(torrent["leechers"])
-        except ValueError:
-            seeders = 0
-            leechers = 0
-
         results.append({
             "href": "thepiratebay.org",
             "title": torrent["name"],
             "magnet": generate_magnet_link(torrent["info_hash"]),
             "size": convert_bytes(int(torrent["size"])),
             "views": None,
-            "seeders": seeders,
-            "leechers": leechers
+            "seeders": int(torrent["seeders"]),
+            "leechers": int(torrent["leechers"])
         })
 
     return results

--- a/src/torrent_sites/thepiratebay.py
+++ b/src/torrent_sites/thepiratebay.py
@@ -18,7 +18,7 @@ def convert_bytes(size):
 
 def search(query):
     url = f"https://{API_BAY_DOMAIN}/q.php?q={quote(query)}&cat="
-    torrent_data = helpers.makeHTMLRequest(url)
+    torrent_data = helpers.makeJSONRequest(url)
     results = []
 
     for torrent in torrent_data:

--- a/src/torrent_sites/torrentgalaxy.py
+++ b/src/torrent_sites/torrentgalaxy.py
@@ -30,7 +30,7 @@ def search(query):
         results.append({
             "href": TORRENTGALAXY_DOMAIN,
             "title": title,
-            "magnet": magnet_link,
+            "magnet": helpers.apply_trackers(magnet_link),
             "size": file_size,
             "views": view_count,
             "seeders": seeder,

--- a/src/torrent_sites/torrentgalaxy.py
+++ b/src/torrent_sites/torrentgalaxy.py
@@ -11,7 +11,6 @@ def search(query):
     result_divs = soup.findAll("div", {"class": "tgxtablerow"})
     title = [div.find("div", {"id": "click"}) for div in result_divs]
     title = [title.text.strip() for title in title]
-    hrefs = [TORRENTGALAXY_DOMAIN for title in title]
     magnet_links = [
         div.find("a", href=lambda href: href and href.startswith("magnet")).get("href")
         for div in result_divs
@@ -26,10 +25,10 @@ def search(query):
 
     # list
     results = []
-    for href, title, magnet_link, file_size, view_count, seeder, leecher in zip(
-        hrefs, title, magnet_links, file_sizes, view_counts, seeders, leechers):
+    for title, magnet_link, file_size, view_count, seeder, leecher in zip(
+        title, magnet_links, file_sizes, view_counts, seeders, leechers):
         results.append({
-            "href": href,
+            "href": TORRENTGALAXY_DOMAIN,
             "title": title,
             "magnet": magnet_link,
             "size": file_size,

--- a/src/torrents.py
+++ b/src/torrents.py
@@ -3,7 +3,7 @@ import json
 from src.helpers import latest_commit
 from _config import *
 from flask import request, render_template, jsonify, Response
-from src.torrent_sites import torrentgalaxy, nyaa
+from src.torrent_sites import torrentgalaxy, nyaa, thepiratebay
 
 def torrentResults(query) -> Response:
     if not TORRENTSEARCH_ENABLED:
@@ -24,6 +24,7 @@ def torrentResults(query) -> Response:
     sites = [
         torrentgalaxy,
         nyaa,
+        thepiratebay,
     ]
 
     results = []

--- a/src/torrents.py
+++ b/src/torrents.py
@@ -3,7 +3,7 @@ import json
 from src.helpers import latest_commit
 from _config import *
 from flask import request, render_template, jsonify, Response
-from src.torrent_sites import torrentgalaxy, nyaa, thepiratebay
+from src.torrent_sites import torrentgalaxy, nyaa, thepiratebay, rutor
 
 def torrentResults(query) -> Response:
     if not TORRENTSEARCH_ENABLED:
@@ -25,6 +25,7 @@ def torrentResults(query) -> Response:
         torrentgalaxy,
         nyaa,
         thepiratebay,
+        rutor,
     ]
 
     results = []


### PR DESCRIPTION
This PR adds rutor and thepiratebay as extra torrent search engines.
I haven't been able to test if this works, since I don't have a VPN and my ISP blocks torrent sites, so please check if it does work.