### PR TITLE
Make images.py and videos.py more readable.

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -124,16 +124,18 @@ def wikipedia():
 
 @app.route("/api")
 def api():
-    if API_ENABLED == True:
+    if API_ENABLED:
         query = request.args.get("q", "").strip()
         t = request.args.get("t", "text").strip()
-        p = (request.args.get('p', 1))
-        try:
-            response = requests.get(f"http://localhost:{PORT}/search?q={query}&t={t}&api=true&p={p}")
-            return json.loads(response.text)
-        except Exception as e:
-            app.logger.error(e)
-            return jsonify({"error": "An error occurred while processing the request"}), 500
+        match t:
+            case "torrent":
+                return torrents.torrentResults(query, api=True)
+            case "video":
+                return video.videoResults(query, api=True)
+            case "image":
+                return images.imageResults(query, api=True)
+            case _:
+                return textResults.textResults(query, api=True)
     else:
         return jsonify({"error": "API disabled by instance operator"}), 503
 

--- a/__init__.py
+++ b/__init__.py
@@ -127,15 +127,14 @@ def api():
     if API_ENABLED:
         query = request.args.get("q", "").strip()
         t = request.args.get("t", "text").strip()
-        match t:
-            case "torrent":
-                return torrents.torrentResults(query, api=True)
-            case "video":
-                return video.videoResults(query, api=True)
-            case "image":
-                return images.imageResults(query, api=True)
-            case _:
-                return textResults.textResults(query, api=True)
+        if t == "torrent":
+            return torrents.torrentResults(query, api=True)
+        elif t == "video":
+            return video.videoResults(query, api=True)
+        elif t == "image":
+            return images.imageResults(query, api=True)
+        else:
+            return textResults.textResults(query, api=True)
     else:
         return jsonify({"error": "API disabled by instance operator"}), 503
 

--- a/_config.py
+++ b/_config.py
@@ -69,13 +69,13 @@ WHITELISTED_DOMAINS = [
 
 ENABLED_TORRENT_SITES = [
     "nyaa",
-    "torrentgalaxy",
+    # "torrentgalaxy",
 ]
 
 COOKIE_AGE = 2147483647
 
-# set to true to enable api support
-API_ENABLED = False
+# set to True to enable api support
+API_ENABLED = True
 
 # set to false to disable torrent search
 TORRENTSEARCH_ENABLED = True

--- a/_config.py
+++ b/_config.py
@@ -69,7 +69,7 @@ WHITELISTED_DOMAINS = [
 
 ENABLED_TORRENT_SITES = [
     "nyaa",
-    # "torrentgalaxy",
+    "torrentgalaxy",
 ]
 
 COOKIE_AGE = 2147483647

--- a/src/images.py
+++ b/src/images.py
@@ -7,35 +7,11 @@ import json
 from urllib.parse import quote
 import base64
 
-# try:
-#     # get 'img' ellements
-#     ellements = soup.findAll("div", {"class": "images-container"})
-#     # get source urls
-#     image_sources = [a.find('img')['src'] for a in ellements[0].findAll('a') if a.find('img')]
-# except:
-#     return redirect('/search')
-#
-# # get alt tags
-# image_alts = [img['alt'] for img in ellements[0].findAll('img', alt=True)]
-#
-# # generate results
-# images = [f"/img_proxy?url={quote(img_src)}" for img_src in image_sources]
-#
-# # decode urls
-# links = [a['href'] for a in ellements[0].findAll('a') if a.has_attr('href')]
-# links = [url.split("?position")[0].split("==/")[-1] for url in links]
-# links = [unquote(base64.b64decode(link).decode('utf-8')) for link in links]
-#
-# # list
-# results = []
-# for image, link, image_alt in zip(images, links, image_alts):
-#     results.append((image, link, image_alt))
-
 def generate_proxy_link(link):
     link = link.split("?position")[0].split("==/")[-1]
     return unquote(base64.b64decode(link).decode('utf-8'))
 
-def imageResults(query) -> Response:
+def imageResults(query, api=False) -> Response:
     # get user language settings
     ux_lang = request.cookies.get('ux_lang', 'english')
     json_path = f'static/lang/{ux_lang}.json'
@@ -44,8 +20,6 @@ def imageResults(query) -> Response:
 
     # remember time we started
     start_time = time.time()
-
-    api = request.args.get("api", "false")
 
     try:
         p = int(request.args.get('p', 1))
@@ -74,7 +48,7 @@ def imageResults(query) -> Response:
     elapsed_time = end_time - start_time
 
     # render
-    if api == "true" and API_ENABLED:
+    if api and API_ENABLED:
         # return the results list as a JSON response
         return jsonify(results)
     else:

--- a/src/textResults.py
+++ b/src/textResults.py
@@ -8,7 +8,7 @@ import re
 from math import isclose # For float comparisons
 
 
-def textResults(query) -> Response:
+def textResults(query, api=False) -> Response:
     # get user language settings
     ux_lang = request.cookies.get('ux_lang', 'english')
     json_path = f'static/lang/{ux_lang}.json'
@@ -18,7 +18,6 @@ def textResults(query) -> Response:
     # remember time we started
     start_time = time.time()
 
-    api = request.args.get("api", "false")
     search_type = request.args.get("t", "text")
     p = request.args.get("p", 0)
     lang = request.cookies.get('lang', '')
@@ -201,7 +200,7 @@ def textResults(query) -> Response:
     if "exported_math_expression" not in locals():
         exported_math_expression = ""
 
-    if api == "true" and API_ENABLED == True:
+    if api and API_ENABLED:
         # return the results list as a JSON response
         return jsonify(results)
     else:

--- a/src/torrents.py
+++ b/src/torrents.py
@@ -5,7 +5,7 @@ from _config import *
 from flask import request, render_template, jsonify, Response
 from src.torrent_sites import torrentgalaxy, nyaa
 
-def torrentResults(query) -> Response:
+def torrentResults(query, api=False) -> Response:
     if not TORRENTSEARCH_ENABLED:
         return jsonify({"error": "Torrent search disabled by instance operator"}), 503
 
@@ -18,7 +18,6 @@ def torrentResults(query) -> Response:
     # remember time we started
     start_time = time.time()
 
-    api = request.args.get("api", "false")
     query = request.args.get("q", " ").strip()
 
     sites = [
@@ -38,7 +37,7 @@ def torrentResults(query) -> Response:
     end_time = time.time()
     elapsed_time = end_time - start_time
 
-    if api == "true" and API_ENABLED:
+    if api and API_ENABLED:
         # return the results list as a JSON response
         return jsonify(results)
 

--- a/src/video.py
+++ b/src/video.py
@@ -7,7 +7,7 @@ from src.helpers import latest_commit
 from urllib.parse import quote
 
 
-def videoResults(query) -> Response:
+def videoResults(query, api=False) -> Response:
     # get user language settings
     ux_lang = request.cookies.get('ux_lang', 'english')
     json_path = f'static/lang/{ux_lang}.json'
@@ -16,8 +16,6 @@ def videoResults(query) -> Response:
 
     # remember time we started
     start_time = time.time()
-
-    api = request.args.get("api", "false")
 
     # grab & format webpage
     soup = makeHTMLRequest(f"https://{INVIDIOUS_INSTANCE}/api/v1/search?q={quote(query)}")
@@ -63,7 +61,7 @@ def videoResults(query) -> Response:
     end_time = time.time()
     elapsed_time = end_time - start_time
 
-    if api == "true" and API_ENABLED == True:
+    if api and API_ENABLED:
         # return the results list as a JSON response
         return jsonify(results)
     else:

--- a/templates/images.html
+++ b/templates/images.html
@@ -24,8 +24,8 @@
         </div>
         {% for result in results %}
         <div class="image">
-        <a class="clickable" {% if new_tab == "active" %} target="_blank" {% endif %} href="{{ result[1] }}">
-            <img class="open-image-viewer" src="{{ result[0] }}" alt="{{ result[2] }}"/>
+        <a class="clickable" {% if new_tab == "active" %} target="_blank" {% endif %} href="{{ result['origin_link'] }}">
+            <img class="open-image-viewer" src="{{ result['image_source'] }}" alt="{{ result['desc'] }}"/>
         </a>
         </div>
         {% endfor %}

--- a/templates/videos.html
+++ b/templates/videos.html
@@ -6,14 +6,14 @@
         {% for result in results %}
         <div><div class="video__results">
         <div class="video__img__results">
-            <img src="{{ result[6] }}">
-                <div class="duration">{{ result[7] }}</div>
+            <img src="{{ result['thumbnail'] }}">
+                <div class="duration">{{ result['length'] }}</div>
             </img>
         </div>
             <div class="results">
-            <a {% if new_tab == "active" %} target="_blank" {% endif %} href="{{ result[0] }}"><h3 class="video_title" href="{{ result[0] }}">{{ result[1] }}</h3></a>
-            <p class="stats">{{ result[3] }} • {{ result[2] }}</p>
-            <p class="publish__info">{{ result[5] }} <span class="pipe">|</span> {{ result[4] }}</p>
+            <a {% if new_tab == "active" %} target="_blank" {% endif %} href="{{ result['link'] }}"><h3 class="video_title">{{ result['title'] }}</h3></a>
+            <p class="stats">{{ result['views'] }} • {{ result['date_span'] }}</p>
+            <p class="publish__info">{{ result['publisher'] }} <span class="pipe">|</span> {{ result['author'] }}</p>
         </div>
     </div>
 </div>


### PR DESCRIPTION
Right now, there's a just  a tone of inline for loops. This makes it harder to read, as everything's all over the place.
This PR replaces all that with one single for loop for all the results, which appends a dict to the results var. This makes it more readable, since everything's in one place, and doesn't have any hidden inline logic.
This also makes the api self documenting. Before this PR, you have to know the exact index of each item you want to get. Now, you can use a named key to grab the item you want.
This also removes the requests.get in `__init__.py` that gets localhost.
I would have done it for the text results too, but as you mentioned in #68, you're working on something with that, and interfering with the text results might cause some conflicts.