### PR TITLE
Add AI answer feature for quick answers

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -2,6 +2,8 @@ from flask import Flask, request, render_template, jsonify, Response, make_respo
 import requests
 import random
 import json
+import urllib
+from flask_cors import CORS, cross_origin
 from _config import *
 from src import textResults, torrents, helpers, images, video
 
@@ -16,6 +18,8 @@ for bang, url in bjson.items():
 app = Flask(__name__, static_folder="static", static_url_path="")
 app.jinja_env.filters['highlight_query_words'] = helpers.highlight_query_words
 app.jinja_env.globals.update(int=int)
+
+CORS(app, resources={r"/api/*": {"origins": "*"}})
 
 COMMIT = helpers.latest_commit()
 
@@ -161,6 +165,21 @@ def img_proxy():
     else:
         # Return an error response if the request failed
         return Response("Error fetching image", status=500)
+
+
+@app.route("/answers", methods=["GET"])
+@cross_origin()
+def answers():
+    query = request.args.get("q", "").strip()
+    print(query)
+    url = f"https://search.brave.com/api/summarizer?key={urllib.parse.quote(query)}%3Agb%3Aen"
+
+    response = requests.get(
+        url,
+        headers={"User-Agent": random.choice(user_agents)}
+    )
+
+    return jsonify(json.loads(response.content))
 
 
 @app.route("/", methods=["GET", "POST"])

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,3 +5,4 @@ gunicorn
 requests
 thefuzz
 langdetect
+flask_cors

--- a/static/css/style.css
+++ b/static/css/style.css
@@ -1241,6 +1241,34 @@ p {
     letter-spacing: normal;
 }
 
+.answer-box {
+  background: var(--snip-background);
+  border: 1px solid var(--snip-border);
+  max-width: 600px;
+  margin-left: 170px;
+  padding: 15px;
+  border-radius: 8px;
+  margin-bottom: 12px;
+}
+
+.refs sup {
+  text-decoration: underline;
+  margin: 0px 3px;
+}
+
+.block:hover {
+  background: #404042;
+}
+
+a.reference {
+  display: inline-block;
+  color: var(--font-fg);
+  margin-right: 10px;
+  padding: 2px;
+  margin-top: 10px;
+  border-radius: 3px;
+}
+
 @media only screen and (max-width: 1320px) {
 
     .snip {
@@ -1258,6 +1286,10 @@ p {
 }
 
 @media only screen and (max-width: 750px) {
+    .answer-box {
+      margin-left: 10px;
+      max-width: 86%;
+    }
 
     .snip,
     .no-results-found {

--- a/static/quickAnswers.js
+++ b/static/quickAnswers.js
@@ -1,0 +1,100 @@
+function getAnswers(query) {
+  return fetch(`/answers?q=${encodeURIComponent(query)}`)
+    .then(response => {
+      return response.json();
+    })
+    .catch(error => {
+      console.error(error);
+      throw error;
+    });
+}
+
+function applyAnswers() {
+  let params = new URLSearchParams(window.location.search);
+  let query = params.get("q");
+
+  getAnswers(query)
+    .then(data => {
+      addToPage(data);
+    })
+    .catch(error => {
+      console.error(error);
+      return
+    });
+}
+
+function getElemByReference(ref) {
+  let results = [];
+  let selectResults = document.querySelectorAll(".block")
+  for (let i = 0; i < selectResults.length; i++) {
+    elem = selectResults[i];
+    if (elem.attributes['data-ref'].nodeValue.includes(String(ref))) {
+      results.push(elem);
+    }
+  }
+  return results;
+}
+
+function addToPage(data) {
+  if (data['status'] == 'failed') {
+    return;
+  }
+  let result = data['results'][0]
+
+  let answerBox = document.createElement('div');
+  answerBox.className = "answer-box";
+
+  let answerText = document.createElement("div");
+  answerText.innerHTML = result.text;
+  answerText.className = "answer-text";
+
+  let references = document.createElement("div");
+  references.className = "references";
+  for (let i = 0; i < result['references'].length; i++) {
+    ref = result['references'][i]
+    let reference = document.createElement("a");
+    reference.innerText = String(i) + " - " + ref['name'];
+    reference['href'] = ref['url'];
+    reference.classList = "reference";
+    reference.classList.add("ref-" + i);
+    reference.refID = i;
+    reference.addEventListener('mouseenter', () => {
+      results = getElemByReference(i);
+      for (let i = 0; i < results.length; i++) {
+        results[i].style.background = '#404042';
+      }
+    })
+    reference.addEventListener('mouseleave', (e) => {
+      results = getElemByReference(i);
+      for (let i = 0; i < results.length; i++) {
+        results[i].style.background = '';
+      }
+    })
+    references.append(reference)
+  }
+
+  answerStrings = answerText.querySelectorAll(".block");
+  for (let i = 0; i < answerStrings.length; i++) {
+    let elem = answerStrings[i];
+    let refs = elem.attributes['data-ref'].nodeValue.split("-");
+    elem.addEventListener("mouseenter", () => {
+      for (const j of refs) {
+        document.querySelector(".ref-" + j).style.background = '#404042'
+      }
+    })
+    elem.addEventListener("mouseleave", () => {
+      for (const j of refs) {
+        document.querySelector(".ref-" + j).style.background = ''
+      }
+    })
+  }
+
+  answerBox.prepend(answerText);
+  answerBox.append(references);
+
+  document.querySelector(".fetched").after(answerBox);
+
+  document.querySelector(".snip").style.marginTop = "-270px"
+}
+
+applyAnswers();

--- a/templates/results_layout.html
+++ b/templates/results_layout.html
@@ -182,6 +182,7 @@
         <script defer src="/menu.js"></script>
         <script defer src="/cookies.js"></script>
         <script defer src="/uxlang.js"></script>
+        <script defer src="/quickAnswers.js"></script>
           {% if not calc == "" and type == "text" %}
           <script defer src="/calculator.js"></script>
           {% endif %}


### PR DESCRIPTION
This is in response to  #78.
This uses brave search's AI answer feature to get AI answers to queries.
Here's an example: https://imgur.com/AqJEWsH
It highlights the reference(s) when you hover over a piece of the text, and vice versa.
Do note that it isn't instant, because it uses a JS fetch in the browser, after the page has been rendered. It's done this way to stop it from interfering with the speed of the backend rendering of the page.