### PR TITLE
Fix multiple bugs + some QOL.

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -2,6 +2,7 @@ from flask import Flask, request, render_template, jsonify, Response, make_respo
 import requests
 import random
 import json
+from urllib.parse import quote
 from _config import *
 from src import textResults, torrents, helpers, images, video
 
@@ -111,7 +112,7 @@ def save_settings():
 @app.route("/suggestions")
 def suggestions():
     query = request.args.get("q", "").strip()
-    response = requests.get(f"https://ac.duckduckgo.com/ac?q={query}&type=list")
+    response = requests.get(f"https://ac.duckduckgo.com/ac?q={quote(query)}&type=list")
     return json.loads(response.text)
 
 
@@ -199,6 +200,7 @@ def search():
         bangkey = query[bang_index + len(BANG):query.index(" ", bang_index)].lower()
         if SEARCH_BANGS.get(bangkey) is not None:
             query = query.lower().replace(BANG + bangkey, "").lstrip()
+            query = quote(query) # Quote the query to redirect properly.
             return app.redirect(SEARCH_BANGS[bangkey].format(query))
         # Remove the space at the end of the query.
         # The space was added to fix a possible error 500 when

--- a/src/torrents.py
+++ b/src/torrents.py
@@ -49,7 +49,7 @@ def torrentResults(query) -> Response:
                         q=f"{query}", fetched=f"{elapsed_time:.2f}",
                         theme=request.cookies.get('theme', DEFAULT_THEME), DEFAULT_THEME=DEFAULT_THEME,
                         javascript=request.cookies.get('javascript', 'enabled'), type="torrent",
-                        repo_url=REPO, API_ENABLED=API_ENABLED, TORRENTSEARCH_ENABLED=TORRENTSEARCH_ENABLED, 
+                        repo_url=REPO, API_ENABLED=API_ENABLED, TORRENTSEARCH_ENABLED=TORRENTSEARCH_ENABLED,
                         ux_lang=ux_lang, lang_data=lang_data,
                         commit=latest_commit()
                         )

--- a/static/calculator.js
+++ b/static/calculator.js
@@ -41,71 +41,96 @@ document.body.addEventListener('keydown', (key) => {
     return;
   }
 
-  if ('0123456789()+-*/.'.includes(key.key)) {
-    if (parseInt(calcInput.textContent) === 0 && key.key !== ".") {
-      calcInput.textContent = "";
-    }
-    calcInput.textContent += key.key;
+  if ('0123456789().'.includes(key.key)) {
+    numberButtonHandle(key.key);
   }
-  if (key.key === "Backspace") {
-    if (calcInput.textContent.length === 1) {
-      calcInput.textContent = "0";
-    } else {
-      calcInput.textContent = calcInput.textContent.slice(0, -1);
-    }
+  else if ('+-*/'.includes(key.key)) {
+    calcInput.textContent += ` ${key.key}`;
+  }
+  else switch (key.key) {
+    case 'Backspace':
+      doBackspace();
+      break;
+    case 'Enter':
+      evaluateExpression();
+      break;
   }
 })
 
 numberButtons.forEach(button => {
-  button.addEventListener('click', () => {
-    // remove any 0 output.
-    if (parseInt(calcInput.textContent) === 0 && button.textContent !== ".") {
-      calcInput.textContent = "";
-    }
-
-    calcInput.textContent += button.textContent;
-  });
+  button.addEventListener('click', () => numberButtonHandle(button.textContent));
 });
 
 addBtn.addEventListener('click', () => {
-  calcInput.textContent += ' + ';
+  calcInput.textContent += ' +';
 });
 
 subtractBtn.addEventListener('click', () => {
-  calcInput.textContent += ' - ';
+  calcInput.textContent += ' -';
 });
 
 multiplyBtn.addEventListener('click', () => {
-  calcInput.textContent += ' * ';
+  calcInput.textContent += ' *';
 });
 
 divideBtn.addEventListener('click', () => {
-  calcInput.textContent += ' / ';
+  calcInput.textContent += ' /';
 });
 
 clearBtn.addEventListener('click', () => {
   calcInput.textContent = '0';
 });
 
-backspaceBtn.addEventListener('click', () => {
-  calcInput.textContent = calcInput.textContent.slice(0, -1);
-});
+backspaceBtn.addEventListener('click', doBackspace);
 
-equalsBtn.addEventListener('click', () => {
-  const expression = calcInput.textContent;
-  const result = evaluateExpression(expression);
-  document.querySelector(".prev_calculation").textContent = expression;
-  calcInput.textContent = result;
-});
+equalsBtn.addEventListener('click', evaluateExpression);
 
-// Implementation from https://github.com/TommyPang/SimpleCalculator
+// Executes a 'backspace' on the calculator's expression.
+// Made to reduce repetitive code.
+function doBackspace() {
+  do {
+    calcInput.textContent = calcInput.textContent.slice(0, -1);
+  } while (calcInput.textContent.endsWith(' '));
+  // ^^^ Sometimes there are spaces in the expression (see above listeners).
+  // Remove them aswell.
 
-function evaluateExpression(expression) {
-  expression = expression.replace(/\s/g, '');
-  return helper(Array.from(expression), 0);
+  // If the contents of calcInput have been completely cleared, output 0
+  // to the textbox to match the clear button's behaviour.
+  if (calcInput.textContent.length === 0) {
+    calcInput.textContent = '0';
+  }
 }
 
-function helper(s, idx) {
+// Handles the presses to all numberButtons.
+function numberButtonHandle(button) {
+  // remove any 0 output.
+  if (calcInput.textContent === '0' && button !== ".") {
+    calcInput.textContent = "";
+  }
+
+  // If the end of calcInput has an operator, append an extra space for
+  // the number to make the expression look better.
+  if (/\+|\-|\*|\//.test(calcInput.textContent[calcInput.textContent.length - 1])) {
+    calcInput.textContent += ' ';
+  }
+
+  // If statement will prevent multiple dots.
+  if (!(calcInput.textContent.includes('.') && button === '.')) {
+    calcInput.textContent += button;
+  }
+}
+
+// Implementation from https://github.com/TommyPang/SimpleCalculator.
+// Slightly modified.
+
+function evaluateExpression() {
+  let expression = calcInput.textContent;
+  document.querySelector(".prev_calculation").textContent = expression;
+  expression = expression.replace(/\s/g, '');
+  calcInput.textContent = helper(Array.from(expression));
+}
+
+function helper(s, idx = 0) {
   var stk = [];
   let sign = '+';
   let num = 0;

--- a/static/script.js
+++ b/static/script.js
@@ -32,7 +32,8 @@ const resultsWrapper = document.querySelector('.autocomplete');
 
 async function getSuggestions(query) {
   try {
-    const response = await fetch(`/suggestions?q=${query}`);
+    params = new URLSearchParams({"q": query}).toString();
+    const response = await fetch(`/suggestions?${params}`);
     const data = await response.json();
     return data[1]; // Return only the array of suggestion strings
   } catch (error) {

--- a/templates/results.html
+++ b/templates/results.html
@@ -73,9 +73,7 @@
               <div class="prev_calculation">
                 {{ exported_math_expression }}
               </div>
-              <div id="current_calc">
-                {{ calc }}
-              </div>
+              <div id="current_calc">{{ calc }}</div>
             </div>
         <div class="calc-btns">
             <button class="btn-nostyle"><div class="calc-btn calc-btn-style clickable">(</div></button>


### PR DESCRIPTION
- BUG FIX: Suggestions were not being quoted, causing queries like "c++ hello world" to show suggestions for C;
### _Before:_
![image](https://github.com/Extravi/araa-search/assets/80432271/b4884db0-5547-49f6-9e6f-831e2d4e9ab5)
### _After:_
![image](https://github.com/Extravi/araa-search/assets/80432271/ccaff430-2b22-4cc1-bee5-94c548ab17a5)

- BUG FIX: Bang redirects were not being quoted, causing queries like "!g c++ compiler download" to redirect to Google with "c compiler download".

- BUG FIX: The calculator used to sometimes not remove characters from an expression when backspace is pressed. This was due to the expression sometimes containing spaces (ex. `"2 + 2 "` would become `"2 + 2"` when backspace was pressed).

- BUG FIX; Typing in an expression into the calculator with the keyboard is now consistent with using the virtual buttons in terms of functionality.

- BUG FIX; Using backspace to clear an equation will now mimic hitting the CE button; 0 will be output instead of nothing.

- QOL; Hitting the enter key with the calculator will now evaluate the expression.