### PR TITLE
Move all settings into one class

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -23,56 +23,38 @@ COMMIT = helpers.latest_commit()
 
 @app.route('/settings')
 def settings():
-    # default theme if none is set
-    theme = request.cookies.get('theme', DEFAULT_THEME)
-    lang = request.cookies.get('lang')
-    safe = request.cookies.get('safe')
-    new_tab = request.cookies.get('new_tab')
-    domain = request.cookies.get('domain')
-    javascript = request.cookies.get('javascript', 'enabled')
+    settings = helpers.Settings()
 
     # get user language settings
-    ux_lang = request.cookies.get('ux_lang', 'english')
-    json_path = f'static/lang/{ux_lang}.json'
+    json_path = f'static/lang/{settings.ux_lang}.json'
     with open(json_path, 'r') as file:
         lang_data = json.load(file)
 
     return render_template('settings.html',
-                           theme=theme,
-                           lang=lang,
-                           ux_lang=ux_lang,
-                           lang_data=lang_data,
-                           safe=safe,
-                           new_tab=new_tab,
-                           domain=domain,
-                           javascript=javascript,
                            commit=COMMIT,
                            repo_url=REPO,
                            current_url=request.url,
-                           API_ENABLED=API_ENABLED
+                           API_ENABLED=API_ENABLED,
+                           settings=settings,
+                           lang_data=lang_data
                            )
 
 @app.route('/discover')
 def discover():
-    # default theme if none is set
-    theme = request.cookies.get('theme', DEFAULT_THEME)
-    javascript = request.cookies.get('javascript', 'enabled')
+    settings = helpers.Settings()
 
     # get user language settings
-    ux_lang = request.cookies.get('ux_lang', 'english')
-    json_path = f'static/lang/{ux_lang}.json'
+    json_path = f'static/lang/{settings.ux_lang}.json'
     with open(json_path, 'r') as file:
         lang_data = json.load(file)
 
     return render_template('discover.html',
-                           theme=theme,
-                           javascript=javascript,
-                           ux_lang=ux_lang,
                            lang_data=lang_data,
                            commit=COMMIT,
                            repo_url=REPO,
                            current_url=request.url,
-                           API_ENABLED=API_ENABLED
+                           API_ENABLED=API_ENABLED,
+                           settings=settings
                            )
 
 
@@ -156,26 +138,19 @@ def search():
     if request.method != "GET":
         return Response(f"Error; expected GET request, got {request.method}", status=400)
 
-    lang = request.cookies.get('lang')
-    domain = request.cookies.get('domain')
+    settings = helpers.Settings()
 
     # get user language settings
-    ux_lang = request.cookies.get('ux_lang', 'english')
-    json_path = f'static/lang/{ux_lang}.json'
+    json_path = f'static/lang/{settings.ux_lang}.json'
     with open(json_path, 'r') as file:
         lang_data = json.load(file)
 
     # get the `q` query parameter from the URL
     query = request.args.get("q", "").strip()
     if query == "":
-        if request.cookies.get('theme', DEFAULT_THEME) == 'dark_blur':
-            css_style = "dark_blur_beta.css"
-        else:
-            css_style = None
-        return render_template("search.html", theme = request.cookies.get('theme', DEFAULT_THEME),
-            javascript=request.cookies.get('javascript', 'enabled'), DEFAULT_THEME=DEFAULT_THEME,
-            css_style=css_style, repo_url=REPO, commit=COMMIT, API_ENABLED=API_ENABLED,
-            lang=lang, domain=domain, lang_data=lang_data, ux_lang=ux_lang)
+        return render_template("search.html",
+            repo_url=REPO, commit=COMMIT, API_ENABLED=API_ENABLED,
+            lang_data=lang_data, settings=settings)
 
     # Check if the query has a bang.
     if BANG in query:

--- a/src/helpers.py
+++ b/src/helpers.py
@@ -9,6 +9,7 @@ from markupsafe import escape, Markup
 from os.path import exists
 from langdetect import detect
 from thefuzz import fuzz
+from flask import request
 
 
 def makeHTMLRequest(url: str):
@@ -113,3 +114,13 @@ def bytes_to_string(size):
         size /= 1024
         index += 1
     return f"{size:.2f} {units[index]}"
+
+class Settings():
+    def __init__(self):
+        self.domain = request.cookies.get("domain", "google.com/search?gl=us")
+        self.javascript = request.cookies.get("javascript", "enabled")
+        self.lang = request.cookies.get("lang", "")
+        self.new_tab = request.cookies.get("new_tab", "")
+        self.safe = request.cookies.get("safe", "active")
+        self.ux_lang = request.cookies.get("ux_lang", "english")
+        self.theme = request.cookies.get("theme", DEFAULT_THEME)

--- a/src/images.py
+++ b/src/images.py
@@ -1,4 +1,4 @@
-from src.helpers import makeHTMLRequest, latest_commit
+from src import helpers
 from urllib.parse import unquote, quote
 from _config import *
 from flask import request, render_template, jsonify, Response, redirect
@@ -10,8 +10,9 @@ import base64
 
 def imageResults(query) -> Response:
     # get user language settings
-    ux_lang = request.cookies.get('ux_lang', 'english')
-    json_path = f'static/lang/{ux_lang}.json'
+    settings = helpers.Settings()
+
+    json_path = f'static/lang/{settings.ux_lang}.json'
     with open(json_path, 'r') as file:
         lang_data = json.load(file)
 
@@ -25,10 +26,10 @@ def imageResults(query) -> Response:
         return redirect('/search')
 
     # returns 1 if active, else 0
-    safe_search = int(request.cookies.get("safe", "active") == "active")
+    safe_search = int(settings.safe == "active")
 
     # grab & format webpage
-    soup = makeHTMLRequest(f"https://lite.qwant.com/?q={quote(query)}&t=images&p={p}&s={safe_search}")
+    soup = helpers.makeHTMLRequest(f"https://lite.qwant.com/?q={quote(query)}&t=images&p={p}&s={safe_search}")
 
     try:
         # get 'img' ellements
@@ -65,8 +66,7 @@ def imageResults(query) -> Response:
     else:
         return render_template("images.html", results=results, title=f"{query} - Araa",
             q=f"{query}", fetched=f"{elapsed_time:.2f}",
-            theme=request.cookies.get('theme', DEFAULT_THEME), DEFAULT_THEME=DEFAULT_THEME,
-            javascript=request.cookies.get('javascript', 'enabled'), type="image",
-            new_tab=request.cookies.get("new_tab"), repo_url=REPO, API_ENABLED=API_ENABLED,
-            TORRENTSEARCH_ENABLED=TORRENTSEARCH_ENABLED, ux_lang=ux_lang, lang_data=lang_data,
-            commit=latest_commit())
+            type="image",
+            repo_url=REPO, API_ENABLED=API_ENABLED,
+            TORRENTSEARCH_ENABLED=TORRENTSEARCH_ENABLED, lang_data=lang_data,
+            commit=helpers.latest_commit(), settings=settings)

--- a/src/textResults.py
+++ b/src/textResults.py
@@ -1,4 +1,4 @@
-from src.helpers import makeHTMLRequest, latest_commit
+from src import helpers
 from urllib.parse import unquote, quote
 from _config import *
 from flask import request, render_template, jsonify, Response
@@ -10,8 +10,9 @@ from math import isclose # For float comparisons
 
 def textResults(query) -> Response:
     # get user language settings
-    ux_lang = request.cookies.get('ux_lang', 'english')
-    json_path = f'static/lang/{ux_lang}.json'
+    settings = helpers.Settings()
+
+    json_path = f'static/lang/{settings.ux_lang}.json'
     with open(json_path, 'r') as file:
         lang_data = json.load(file)
 
@@ -21,19 +22,15 @@ def textResults(query) -> Response:
     api = request.args.get("api", "false")
     search_type = request.args.get("t", "text")
     p = request.args.get("p", 0)
-    lang = request.cookies.get('lang', '')
-    safe = request.cookies.get('safe', 'active')
-    domain = request.cookies.get('domain', 'google.com/search?gl=us')
-    javascript = request.cookies.get('javascript', 'enabled')
 
     try:
         # search query
         if search_type == "reddit":
             site_restriction = "site:reddit.com"
             query_for_request = f"{query} {site_restriction}"
-            soup = makeHTMLRequest(f"https://www.{domain}&q={quote(query_for_request)}&start={p}&lr={lang}")
+            soup = helpers.makeHTMLRequest(f"https://www.{settings.domain}&q={quote(query_for_request)}&start={p}&lr={settings.lang}")
         elif search_type == "text":
-            soup = makeHTMLRequest(f"https://www.{domain}&q={quote(query)}&start={p}&lr={lang}&safe={safe}")
+            soup = helpers.makeHTMLRequest(f"https://www.{settings.domain}&q={quote(query)}&start={p}&lr={settings.lang}&safe={settings.safe}")
         else:
             return "Invalid search type"
     except Exception as e:
@@ -115,7 +112,7 @@ def textResults(query) -> Response:
         check = check.replace("site:reddit.com", "").strip()
 
     # get image for kno try javascript version first
-    if javascript == "enabled":
+    if settings.javascript == "enabled":
         if kno_link == "":
             kno_image = ""
             kno_title = ""
@@ -215,9 +212,8 @@ def textResults(query) -> Response:
                                snip=f"{snip}", kno_rdesc=f"{kno}", rdesc_link=f"{unquote(kno_link)}",
                                kno_wiki=f"{kno_image}", rkno_title=f"{rkno_title}", kno_title=f"{kno_title}",
                                user_info=f"{info}", calc=f"{calc}", check=check, current_url=current_url,
-                               theme=request.cookies.get('theme', DEFAULT_THEME), new_tab=request.cookies.get("new_tab"),
-                               javascript=request.cookies.get('javascript', 'enabled'), DEFAULT_THEME=DEFAULT_THEME,
-                               type=type, search_type=search_type, repo_url=REPO, lang=lang, safe=safe, commit=latest_commit(),
+                               type=type, search_type=search_type, repo_url=REPO, commit=helpers.latest_commit(),
                                exported_math_expression=exported_math_expression, API_ENABLED=API_ENABLED,
-                               TORRENTSEARCH_ENABLED=TORRENTSEARCH_ENABLED, domain=domain, ux_lang=ux_lang, lang_data=lang_data
+                               TORRENTSEARCH_ENABLED=TORRENTSEARCH_ENABLED, lang_data=lang_data,
+                               settings=settings,
                                )

--- a/src/torrents.py
+++ b/src/torrents.py
@@ -1,17 +1,17 @@
 import time
 import json
-from src.helpers import latest_commit
+from src import helpers
 from _config import *
 from flask import request, render_template, jsonify, Response
 from src.torrent_sites import torrentgalaxy, nyaa, thepiratebay, rutor
 
 def torrentResults(query) -> Response:
+    settings = helpers.Settings()
     if not TORRENTSEARCH_ENABLED:
         return jsonify({"error": "Torrent search disabled by instance operator"}), 503
 
     # get user language settings
-    ux_lang = request.cookies.get('ux_lang', 'english')
-    json_path = f'static/lang/{ux_lang}.json'
+    json_path = f'static/lang/{settings.ux_lang}.json'
     with open(json_path, 'r') as file:
         lang_data = json.load(file)
 
@@ -21,7 +21,6 @@ def torrentResults(query) -> Response:
     api = request.args.get("api", "false")
     catagory = request.args.get("cat", "all")
     query = request.args.get("q", " ").strip()
-    safesearch = request.cookies.get("safe", "active")
     sort = request.args.get("sort", "seed")
     if sort not in ["seed", "leech", "lth", "htl"]:
         sort = "seed"
@@ -50,7 +49,7 @@ def torrentResults(query) -> Response:
             results = sorted(results, key=lambda x: x["leechers"])[::-1]
         case "lth": # Low to High file size
             results = sorted(results, key=lambda x: x["bytes"])
-        case "htl": # Low to High file size
+        case "htl": # High to low file size
             results = sorted(results, key=lambda x: x["bytes"])[::-1]
         case _: # Defaults to seeders
             results = sorted(results, key=lambda x: x["seeders"])[::-1]
@@ -67,10 +66,7 @@ def torrentResults(query) -> Response:
     return render_template("torrents.html",
                         results=results, title=f"{query} - Araa",
                         q=f"{query}", fetched=f"{elapsed_time:.2f}",
-                        cat=catagory, safesearch=safesearch,
-                        theme=request.cookies.get('theme', DEFAULT_THEME), DEFAULT_THEME=DEFAULT_THEME,
-                        javascript=request.cookies.get('javascript', 'enabled'), type="torrent",
-                        repo_url=REPO, API_ENABLED=API_ENABLED, TORRENTSEARCH_ENABLED=TORRENTSEARCH_ENABLED,
-                        ux_lang=ux_lang, lang_data=lang_data,
-                        commit=latest_commit(), sort=sort
+                        cat=catagory, type="torrent", repo_url=REPO, 
+                        API_ENABLED=API_ENABLED, TORRENTSEARCH_ENABLED=TORRENTSEARCH_ENABLED,
+                        lang_data=lang_data, commit=helpers.latest_commit(), sort=sort, settings=settings
                         )

--- a/src/video.py
+++ b/src/video.py
@@ -1,4 +1,5 @@
 from src.helpers import makeHTMLRequest
+from src import helpers
 from _config import *
 from flask import request, render_template, jsonify, Response
 import time
@@ -8,9 +9,9 @@ from urllib.parse import quote
 
 
 def videoResults(query) -> Response:
-    # get user language settings
-    ux_lang = request.cookies.get('ux_lang', 'english')
-    json_path = f'static/lang/{ux_lang}.json'
+    settings = helpers.Settings()
+
+    json_path = f'static/lang/{settings.ux_lang}.json'
     with open(json_path, 'r') as file:
         lang_data = json.load(file)
 
@@ -76,8 +77,6 @@ def videoResults(query) -> Response:
         return render_template("videos.html",
                                results=results, title=f"{query} - Araa",
                                q=f"{query}", fetched=f"{elapsed_time:.2f}",
-                               theme=request.cookies.get('theme', DEFAULT_THEME), DEFAULT_THEME=DEFAULT_THEME,
-                               javascript=request.cookies.get('javascript', 'enabled'), new_tab=request.cookies.get("new_tab"),
-                               type="video", repo_url=REPO, API_ENABLED=API_ENABLED, TORRENTSEARCH_ENABLED=TORRENTSEARCH_ENABLED, ux_lang=ux_lang, 
-                               lang_data=lang_data, commit=latest_commit()
+                               type="video", repo_url=REPO, API_ENABLED=API_ENABLED, TORRENTSEARCH_ENABLED=TORRENTSEARCH_ENABLED,
+                               lang_data=lang_data, commit=latest_commit(), settings=settings
                                )

--- a/templates/discover.html
+++ b/templates/discover.html
@@ -28,7 +28,7 @@
         </div>
         </div>
     </div>
-        {% if javascript == "enabled" %}
+        {% if settings.javascript == "enabled" %}
         <script defer src="/cookies.js"></script>
         <script defer src="/uxlang.js"></script>
         {% endif %}

--- a/templates/images.html
+++ b/templates/images.html
@@ -24,7 +24,7 @@
         </div>
         {% for result in results %}
         <div class="image">
-        <a class="clickable" {% if new_tab == "active" %} target="_blank" {% endif %} href="{{ result[1] }}">
+        <a class="clickable" {% if settings.new_tab == "active" %} target="_blank" {% endif %} href="{{ result[1] }}">
             <img class="open-image-viewer" src="{{ result[0] }}" alt="{{ result[2] }}"/>
         </a>
         </div>

--- a/templates/preresults_layout.html
+++ b/templates/preresults_layout.html
@@ -12,11 +12,7 @@
     <meta content="A privacy-respecting, ad-free, self-hosted metasearch engine." property="og:description">
     <meta content="/" property="og:url">
     <meta content="#5885F4" data-react-helmet="true" name="theme-color">
-    {% if request.cookies.theme %}
-        <link rel="stylesheet" href="./css/{{ request.cookies.theme }}.css">
-    {% else %}
-        <link rel="stylesheet" href="./css/{{ theme }}.css">
-    {% endif %}
+    <link rel="stylesheet" href="./css/{{ settings.theme }}.css">
     {% if request.path == '/settings' or request.path == '/discover' %}
         <link rel="stylesheet" type="text/css" href="{{ url_for('static', filename='css/settings-style.css') }}">
     {% endif %}

--- a/templates/results.html
+++ b/templates/results.html
@@ -4,57 +4,57 @@
     <form class="results_settings" action="/save-settings" method="post">
       <input type="hidden" name="past" value="{{ current_url }}"></input>
       <select class="results-settings" name="safe" id="safeSearchSelect">
-          <option value="active" {% if safe == 'active' %}selected{% endif %}>{{ lang_data.settings.safe_search }} {{ lang_data.settings.on }}</option>
-          <option value="" {% if safe == '' %}selected{% endif %}>{{ lang_data.settings.safe_search }} {{ lang_data.settings.off }}</option>
+          <option value="active" {% if settings.safe == 'active' %}selected{% endif %}>{{ lang_data.settings.safe_search }} {{ lang_data.settings.on }}</option>
+          <option value="" {% if settings.safe == '' %}selected{% endif %}>{{ lang_data.settings.safe_search }} {{ lang_data.settings.off }}</option>
       </select>
       <select class="results-settings" name="lang" id="languageSelect">
-          <option value="" {% if lang == '' %}selected{% endif %}>{{ lang_data.settings.any_language }}</option>
-          <option value="lang_en" {% if lang == 'lang_en' %}selected{% endif %}>English</option>
-          <option value="lang_af" {% if lang == 'lang_af' %}selected{% endif %}>Afrikaans</option>
-          <option value="lang_ar" {% if lang == 'lang_ar' %}selected{% endif %}>العربية (Arabic)</option>
-          <option value="lang_hy" {% if lang == 'lang_hy' %}selected{% endif %}>Հայերեն (Armenian)</option>
-          <option value="lang_be" {% if lang == 'lang_be' %}selected{% endif %}>Беларуская (Belarusian)</option>
-          <option value="lang_bg" {% if lang == 'lang_bg' %}selected{% endif %}>български (Bulgarian)</option>
-          <option value="lang_ca" {% if lang == 'lang_ca' %}selected{% endif %}>Català (Catalan)</option>
-          <option value="lang_zh-CN" {% if lang == 'lang_zh-CN' %}selected{% endif %}>中文 (简体) (Chinese Simplified)</option>
-          <option value="lang_zh-TW" {% if lang == 'lang_zh-TW' %}selected{% endif %}>中文 (繁體) (Chinese Traditional)</option>
-          <option value="lang_hr" {% if lang == 'lang_hr' %}selected{% endif %}>Hrvatski (Croatian)</option>
-          <option value="lang_cs" {% if lang == 'lang_cs' %}selected{% endif %}>Čeština (Czech)</option>
-          <option value="lang_da" {% if lang == 'lang_da' %}selected{% endif %}>Dansk (Danish)</option>
-          <option value="lang_nl" {% if lang == 'lang_nl' %}selected{% endif %}>Nederlands (Dutch)</option>
-          <option value="lang_eo" {% if lang == 'lang_eo' %}selected{% endif %}>Esperanto</option>
-          <option value="lang_et" {% if lang == 'lang_et' %}selected{% endif %}>Eesti (Estonian)</option>
-          <option value="lang_tl" {% if lang == 'lang_tl' %}selected{% endif %}>Filipino (Tagalog)</option>
-          <option value="lang_fi" {% if lang == 'lang_fi' %}selected{% endif %}>Suomi (Finnish)</option>
-          <option value="lang_fr" {% if lang == 'lang_fr' %}selected{% endif %}>Français (French)</option>
-          <option value="lang_de" {% if lang == 'lang_de' %}selected{% endif %}>Deutsch (German)</option>
-          <option value="lang_el" {% if lang == 'lang_el' %}selected{% endif %}>Ελληνικά (Greek)</option>
-          <option value="lang_iw" {% if lang == 'lang_iw' %}selected{% endif %}>עברית (Hebrew)</option>
-          <option value="lang_hi" {% if lang == 'lang_hi' %}selected{% endif %}>हिन्दी (Hindi)</option>
-          <option value="lang_hu" {% if lang == 'lang_hu' %}selected{% endif %}>magyar (Hungarian)</option>
-          <option value="lang_is" {% if lang == 'lang_is' %}selected{% endif %}>íslenska (Icelandic)</option>
-          <option value="lang_id" {% if lang == 'lang_id' %}selected{% endif %}>Bahasa Indonesia (Indonesian)</option>
-          <option value="lang_it" {% if lang == 'lang_it' %}selected{% endif %}>italiano (Italian)</option>
-          <option value="lang_ja" {% if lang == 'lang_ja' %}selected{% endif %}>日本語 (Japanese)</option>
-          <option value="lang_ko" {% if lang == 'lang_ko' %}selected{% endif %}>한국어 (Korean)</option>
-          <option value="lang_lv" {% if lang == 'lang_lv' %}selected{% endif %}>latviešu (Latvian)</option>
-          <option value="lang_lt" {% if lang == 'lang_lt' %}selected{% endif %}>lietuvių (Lithuanian)</option>
-          <option value="lang_no" {% if lang == 'lang_no' %}selected{% endif %}>norsk (Norwegian)</option>
-          <option value="lang_fa" {% if lang == 'lang_fa' %}selected{% endif %}>فارسی (Persian)</option>
-          <option value="lang_pl" {% if lang == 'lang_pl' %}selected{% endif %}>polski (Polish)</option>
-          <option value="lang_pt" {% if lang == 'lang_pt' %}selected{% endif %}>português (Portuguese)</option>
-          <option value="lang_ro" {% if lang == 'lang_ro' %}selected{% endif %}>română (Romanian)</option>
-          <option value="lang_ru" {% if lang == 'lang_ru' %}selected{% endif %}>русский (Russian)</option>
-          <option value="lang_sr" {% if lang == 'lang_sr' %}selected{% endif %}>српски (Serbian)</option>
-          <option value="lang_sk" {% if lang == 'lang_sk' %}selected{% endif %}>slovenčina (Slovak)</option>
-          <option value="lang_sl" {% if lang == 'lang_sl' %}selected{% endif %}>slovenščina (Slovenian)</option>
-          <option value="lang_es" {% if lang == 'lang_es' %}selected{% endif %}>español (Spanish)</option>
-          <option value="lang_sw" {% if lang == 'lang_sw' %}selected{% endif %}>Kiswahili (Swahili)</option>
-          <option value="lang_sv" {% if lang == 'lang_sv' %}selected{% endif %}>svenska (Swedish)</option>
-          <option value="lang_th" {% if lang == 'lang_th' %}selected{% endif %}>ไทย (Thai)</option>
-          <option value="lang_tr" {% if lang == 'lang_tr' %}selected{% endif %}>Türkçe (Turkish)</option>
-          <option value="lang_uk" {% if lang == 'lang_uk' %}selected{% endif %}>українська (Ukrainian)</option>
-          <option value="lang_vi" {% if lang == 'lang_vi' %}selected{% endif %}>Tiếng Việt (Vietnamese)</option>
+          <option value="" {% if settings.lang == '' %}selected{% endif %}>{{ lang_data.settings.any_language }}</option>
+          <option value="lang_en" {% if settings.lang == 'lang_en' %}selected{% endif %}>English</option>
+          <option value="lang_af" {% if settings.lang == 'lang_af' %}selected{% endif %}>Afrikaans</option>
+          <option value="lang_ar" {% if settings.lang == 'lang_ar' %}selected{% endif %}>العربية (Arabic)</option>
+          <option value="lang_hy" {% if settings.lang == 'lang_hy' %}selected{% endif %}>Հայերեն (Armenian)</option>
+          <option value="lang_be" {% if settings.lang == 'lang_be' %}selected{% endif %}>Беларуская (Belarusian)</option>
+          <option value="lang_bg" {% if settings.lang == 'lang_bg' %}selected{% endif %}>български (Bulgarian)</option>
+          <option value="lang_ca" {% if settings.lang == 'lang_ca' %}selected{% endif %}>Català (Catalan)</option>
+          <option value="lang_zh-CN" {% if settings.lang == 'lang_zh-CN' %}selected{% endif %}>中文 (简体) (Chinese Simplified)</option>
+          <option value="lang_zh-TW" {% if settings.lang == 'lang_zh-TW' %}selected{% endif %}>中文 (繁體) (Chinese Traditional)</option>
+          <option value="lang_hr" {% if settings.lang == 'lang_hr' %}selected{% endif %}>Hrvatski (Croatian)</option>
+          <option value="lang_cs" {% if settings.lang == 'lang_cs' %}selected{% endif %}>Čeština (Czech)</option>
+          <option value="lang_da" {% if settings.lang == 'lang_da' %}selected{% endif %}>Dansk (Danish)</option>
+          <option value="lang_nl" {% if settings.lang == 'lang_nl' %}selected{% endif %}>Nederlands (Dutch)</option>
+          <option value="lang_eo" {% if settings.lang == 'lang_eo' %}selected{% endif %}>Esperanto</option>
+          <option value="lang_et" {% if settings.lang == 'lang_et' %}selected{% endif %}>Eesti (Estonian)</option>
+          <option value="lang_tl" {% if settings.lang == 'lang_tl' %}selected{% endif %}>Filipino (Tagalog)</option>
+          <option value="lang_fi" {% if settings.lang == 'lang_fi' %}selected{% endif %}>Suomi (Finnish)</option>
+          <option value="lang_fr" {% if settings.lang == 'lang_fr' %}selected{% endif %}>Français (French)</option>
+          <option value="lang_de" {% if settings.lang == 'lang_de' %}selected{% endif %}>Deutsch (German)</option>
+          <option value="lang_el" {% if settings.lang == 'lang_el' %}selected{% endif %}>Ελληνικά (Greek)</option>
+          <option value="lang_iw" {% if settings.lang == 'lang_iw' %}selected{% endif %}>עברית (Hebrew)</option>
+          <option value="lang_hi" {% if settings.lang == 'lang_hi' %}selected{% endif %}>हिन्दी (Hindi)</option>
+          <option value="lang_hu" {% if settings.lang == 'lang_hu' %}selected{% endif %}>magyar (Hungarian)</option>
+          <option value="lang_is" {% if settings.lang == 'lang_is' %}selected{% endif %}>íslenska (Icelandic)</option>
+          <option value="lang_id" {% if settings.lang == 'lang_id' %}selected{% endif %}>Bahasa Indonesia (Indonesian)</option>
+          <option value="lang_it" {% if settings.lang == 'lang_it' %}selected{% endif %}>italiano (Italian)</option>
+          <option value="lang_ja" {% if settings.lang == 'lang_ja' %}selected{% endif %}>日本語 (Japanese)</option>
+          <option value="lang_ko" {% if settings.lang == 'lang_ko' %}selected{% endif %}>한국어 (Korean)</option>
+          <option value="lang_lv" {% if settings.lang == 'lang_lv' %}selected{% endif %}>latviešu (Latvian)</option>
+          <option value="lang_lt" {% if settings.lang == 'lang_lt' %}selected{% endif %}>lietuvių (Lithuanian)</option>
+          <option value="lang_no" {% if settings.lang == 'lang_no' %}selected{% endif %}>norsk (Norwegian)</option>
+          <option value="lang_fa" {% if settings.lang == 'lang_fa' %}selected{% endif %}>فارسی (Persian)</option>
+          <option value="lang_pl" {% if settings.lang == 'lang_pl' %}selected{% endif %}>polski (Polish)</option>
+          <option value="lang_pt" {% if settings.lang == 'lang_pt' %}selected{% endif %}>português (Portuguese)</option>
+          <option value="lang_ro" {% if settings.lang == 'lang_ro' %}selected{% endif %}>română (Romanian)</option>
+          <option value="lang_ru" {% if settings.lang == 'lang_ru' %}selected{% endif %}>русский (Russian)</option>
+          <option value="lang_sr" {% if settings.lang == 'lang_sr' %}selected{% endif %}>српски (Serbian)</option>
+          <option value="lang_sk" {% if settings.lang == 'lang_sk' %}selected{% endif %}>slovenčina (Slovak)</option>
+          <option value="lang_sl" {% if settings.lang == 'lang_sl' %}selected{% endif %}>slovenščina (Slovenian)</option>
+          <option value="lang_es" {% if settings.lang == 'lang_es' %}selected{% endif %}>español (Spanish)</option>
+          <option value="lang_sw" {% if settings.lang == 'lang_sw' %}selected{% endif %}>Kiswahili (Swahili)</option>
+          <option value="lang_sv" {% if settings.lang == 'lang_sv' %}selected{% endif %}>svenska (Swedish)</option>
+          <option value="lang_th" {% if settings.lang == 'lang_th' %}selected{% endif %}>ไทย (Thai)</option>
+          <option value="lang_tr" {% if settings.lang == 'lang_tr' %}selected{% endif %}>Türkçe (Turkish)</option>
+          <option value="lang_uk" {% if settings.lang == 'lang_uk' %}selected{% endif %}>українська (Ukrainian)</option>
+          <option value="lang_vi" {% if settings.lang == 'lang_vi' %}selected{% endif %}>Tiếng Việt (Vietnamese)</option>
       </select>
       <button class="results-save" type="submit">Apply settings</button>
     </form>
@@ -69,7 +69,7 @@
     {% endif %}
     {% if calc == "" %}
     {% else %}
-    {% if javascript == "enabled" %}
+    {% if settings.javascript == "enabled" %}
         <div class="calc">
             <div class="calc-input" id="calc-input">
               <div class="prev_calculation">
@@ -116,7 +116,7 @@
         {% else %}
         <img src="{{ kno_wiki }}"/>
         {% endif %}
-        {% if javascript == "enabled" %}
+        {% if settings.javascript == "enabled" %}
         <img class="kno_wiki" src=""/>
         {% endif %}
         {{ kno_rdesc }}<a target="_blank" href="{{ rdesc_link }}">{{ rdesc_link }}</a>
@@ -128,8 +128,8 @@
     {% endif %}
     {% if results %}
     <div class="result_sublink">
-      <a id="link" {% if new_tab == "active" %} target="_blank" {% endif %} href="{{ results[0][0] }}">{{ results[0][0] }}</a>
-        <a {% if new_tab == "active"  %} target="_blank" {% endif %} href="{{ results[0][0] }}"><h3>{{ results[0][1] }}</h3></a>
+      <a id="link" {% if settings.new_tab == "active" %} target="_blank" {% endif %} href="{{ results[0][0] }}">{{ results[0][0] }}</a>
+        <a {% if settings.new_tab == "active"  %} target="_blank" {% endif %} href="{{ results[0][0] }}"><h3>{{ results[0][1] }}</h3></a>
         <p>{{ results[0][2]|highlight_query_words(q) }}</p>
     </div>
     {% endif %}
@@ -138,7 +138,7 @@
     <div class="results">
     {% for result in sublink %}
     <div class="sublinks">
-        <a href="{{ result[0] }}" {% if new_tab == "active"  %} target="_blank" {% endif %}><h3>{{ result[1] }}</h3></a>
+        <a href="{{ result[0] }}" {% if settings.new_tab == "active"  %} target="_blank" {% endif %}><h3>{{ result[1] }}</h3></a>
         <p>{{ result[2] }}</p>
     </div>
     {% endfor %}
@@ -148,8 +148,8 @@
     <div class="clean">
         {% for result in results[1:] %}
         <div class="results">
-            <a id="link" href="{{ result[0] }}" {% if new_tab == "active"  %} target="_blank" {% endif %}>{{ result[0] }}</a>
-            <a href="{{ result[0] }}" {% if new_tab == "active"  %} target="_blank" {% endif %}><h3>{{ result[1] }}</h3></a>
+            <a id="link" href="{{ result[0] }}" {% if settings.new_tab == "active"  %} target="_blank" {% endif %}>{{ result[0] }}</a>
+            <a href="{{ result[0] }}" {% if settings.new_tab == "active"  %} target="_blank" {% endif %}><h3>{{ result[1] }}</h3></a>
             <p>{{ result[2]|highlight_query_words(q) }}</p>
         </div>
         {% endfor %}

--- a/templates/results_layout.html
+++ b/templates/results_layout.html
@@ -12,11 +12,7 @@
     <meta content="A privacy-respecting, ad-free, self-hosted metasearch engine." property="og:description">
     <meta content="/" property="og:url">
     <meta content="#5885F4" data-react-helmet="true" name="theme-color">
-    {% if request.cookies.theme %}
-        <link rel="stylesheet" href="./css/{{ request.cookies.theme }}.css">
-    {% else %}
-        <link rel="stylesheet" href="./css/{{ theme }}.css">
-    {% endif %}
+    <link rel="stylesheet" href="./css/{{ settings.theme }}.css">
     <link rel="stylesheet" type="text/css" href="{{ url_for('static', filename='css/style.css') }}">
     <link rel="stylesheet" type="text/css" href="{{ url_for('static', filename='css/menu.css') }}">
     <link rel="search" type="application/opensearchdescription+xml" href="{{ url_for('static', filename='opensearch.xml') }}" title="Araa">
@@ -41,65 +37,65 @@
         </div>
     </div>
     <select class="lang" name="lang">
-        <option value="" {% if lang == '' %}selected{% endif %}>{{ lang_data.settings.any_language }}</option>
-        <option value="lang_en" {% if lang == 'lang_en' %}selected{% endif %}>English</option>
-        <option value="lang_af" {% if lang == 'lang_af' %}selected{% endif %}>Afrikaans</option>
-        <option value="lang_ar" {% if lang == 'lang_ar' %}selected{% endif %}>العربية (Arabic)</option>
-        <option value="lang_hy" {% if lang == 'lang_hy' %}selected{% endif %}>Հայերեն (Armenian)</option>
-        <option value="lang_be" {% if lang == 'lang_be' %}selected{% endif %}>Беларуская (Belarusian)</option>
-        <option value="lang_bg" {% if lang == 'lang_bg' %}selected{% endif %}>български (Bulgarian)</option>
-        <option value="lang_ca" {% if lang == 'lang_ca' %}selected{% endif %}>Català (Catalan)</option>
-        <option value="lang_zh-CN" {% if lang == 'lang_zh-CN' %}selected{% endif %}>中文 (简体) (Chinese Simplified)</option>
-        <option value="lang_zh-TW" {% if lang == 'lang_zh-TW' %}selected{% endif %}>中文 (繁體) (Chinese Traditional)</option>
-        <option value="lang_hr" {% if lang == 'lang_hr' %}selected{% endif %}>Hrvatski (Croatian)</option>
-        <option value="lang_cs" {% if lang == 'lang_cs' %}selected{% endif %}>Čeština (Czech)</option>
-        <option value="lang_da" {% if lang == 'lang_da' %}selected{% endif %}>Dansk (Danish)</option>
-        <option value="lang_nl" {% if lang == 'lang_nl' %}selected{% endif %}>Nederlands (Dutch)</option>
-        <option value="lang_eo" {% if lang == 'lang_eo' %}selected{% endif %}>Esperanto</option>
-        <option value="lang_et" {% if lang == 'lang_et' %}selected{% endif %}>Eesti (Estonian)</option>
-        <option value="lang_tl" {% if lang == 'lang_tl' %}selected{% endif %}>Filipino (Tagalog)</option>
-        <option value="lang_fi" {% if lang == 'lang_fi' %}selected{% endif %}>Suomi (Finnish)</option>
-        <option value="lang_fr" {% if lang == 'lang_fr' %}selected{% endif %}>Français (French)</option>
-        <option value="lang_de" {% if lang == 'lang_de' %}selected{% endif %}>Deutsch (German)</option>
-        <option value="lang_el" {% if lang == 'lang_el' %}selected{% endif %}>Ελληνικά (Greek)</option>
-        <option value="lang_iw" {% if lang == 'lang_iw' %}selected{% endif %}>עברית (Hebrew)</option>
-        <option value="lang_hi" {% if lang == 'lang_hi' %}selected{% endif %}>हिन्दी (Hindi)</option>
-        <option value="lang_hu" {% if lang == 'lang_hu' %}selected{% endif %}>magyar (Hungarian)</option>
-        <option value="lang_is" {% if lang == 'lang_is' %}selected{% endif %}>íslenska (Icelandic)</option>
-        <option value="lang_id" {% if lang == 'lang_id' %}selected{% endif %}>Bahasa Indonesia (Indonesian)</option>
-        <option value="lang_it" {% if lang == 'lang_it' %}selected{% endif %}>italiano (Italian)</option>
-        <option value="lang_ja" {% if lang == 'lang_ja' %}selected{% endif %}>日本語 (Japanese)</option>
-        <option value="lang_ko" {% if lang == 'lang_ko' %}selected{% endif %}>한국어 (Korean)</option>
-        <option value="lang_lv" {% if lang == 'lang_lv' %}selected{% endif %}>latviešu (Latvian)</option>
-        <option value="lang_lt" {% if lang == 'lang_lt' %}selected{% endif %}>lietuvių (Lithuanian)</option>
-        <option value="lang_no" {% if lang == 'lang_no' %}selected{% endif %}>norsk (Norwegian)</option>
-        <option value="lang_fa" {% if lang == 'lang_fa' %}selected{% endif %}>فارسی (Persian)</option>
-        <option value="lang_pl" {% if lang == 'lang_pl' %}selected{% endif %}>polski (Polish)</option>
-        <option value="lang_pt" {% if lang == 'lang_pt' %}selected{% endif %}>português (Portuguese)</option>
-        <option value="lang_ro" {% if lang == 'lang_ro' %}selected{% endif %}>română (Romanian)</option>
-        <option value="lang_ru" {% if lang == 'lang_ru' %}selected{% endif %}>русский (Russian)</option>
-        <option value="lang_sr" {% if lang == 'lang_sr' %}selected{% endif %}>српски (Serbian)</option>
-        <option value="lang_sk" {% if lang == 'lang_sk' %}selected{% endif %}>slovenčina (Slovak)</option>
-        <option value="lang_sl" {% if lang == 'lang_sl' %}selected{% endif %}>slovenščina (Slovenian)</option>
-        <option value="lang_es" {% if lang == 'lang_es' %}selected{% endif %}>español (Spanish)</option>
-        <option value="lang_sw" {% if lang == 'lang_sw' %}selected{% endif %}>Kiswahili (Swahili)</option>
-        <option value="lang_sv" {% if lang == 'lang_sv' %}selected{% endif %}>svenska (Swedish)</option>
-        <option value="lang_th" {% if lang == 'lang_th' %}selected{% endif %}>ไทย (Thai)</option>
-        <option value="lang_tr" {% if lang == 'lang_tr' %}selected{% endif %}>Türkçe (Turkish)</option>
-        <option value="lang_uk" {% if lang == 'lang_uk' %}selected{% endif %}>українська (Ukrainian)</option>
-        <option value="lang_vi" {% if lang == 'lang_vi' %}selected{% endif %}>Tiếng Việt (Vietnamese)</option>
+        <option value="" {% if settings.lang == '' %}selected{% endif %}>{{ lang_data.settings.any_language }}</option>
+        <option value="lang_en" {% if settings.lang == 'lang_en' %}selected{% endif %}>English</option>
+        <option value="lang_af" {% if settings.lang == 'lang_af' %}selected{% endif %}>Afrikaans</option>
+        <option value="lang_ar" {% if settings.lang == 'lang_ar' %}selected{% endif %}>العربية (Arabic)</option>
+        <option value="lang_hy" {% if settings.lang == 'lang_hy' %}selected{% endif %}>Հայերեն (Armenian)</option>
+        <option value="lang_be" {% if settings.lang == 'lang_be' %}selected{% endif %}>Беларуская (Belarusian)</option>
+        <option value="lang_bg" {% if settings.lang == 'lang_bg' %}selected{% endif %}>български (Bulgarian)</option>
+        <option value="lang_ca" {% if settings.lang == 'lang_ca' %}selected{% endif %}>Català (Catalan)</option>
+        <option value="lang_zh-CN" {% if settings.lang == 'lang_zh-CN' %}selected{% endif %}>中文 (简体) (Chinese Simplified)</option>
+        <option value="lang_zh-TW" {% if settings.lang == 'lang_zh-TW' %}selected{% endif %}>中文 (繁體) (Chinese Traditional)</option>
+        <option value="lang_hr" {% if settings.lang == 'lang_hr' %}selected{% endif %}>Hrvatski (Croatian)</option>
+        <option value="lang_cs" {% if settings.lang == 'lang_cs' %}selected{% endif %}>Čeština (Czech)</option>
+        <option value="lang_da" {% if settings.lang == 'lang_da' %}selected{% endif %}>Dansk (Danish)</option>
+        <option value="lang_nl" {% if settings.lang == 'lang_nl' %}selected{% endif %}>Nederlands (Dutch)</option>
+        <option value="lang_eo" {% if settings.lang == 'lang_eo' %}selected{% endif %}>Esperanto</option>
+        <option value="lang_et" {% if settings.lang == 'lang_et' %}selected{% endif %}>Eesti (Estonian)</option>
+        <option value="lang_tl" {% if settings.lang == 'lang_tl' %}selected{% endif %}>Filipino (Tagalog)</option>
+        <option value="lang_fi" {% if settings.lang == 'lang_fi' %}selected{% endif %}>Suomi (Finnish)</option>
+        <option value="lang_fr" {% if settings.lang == 'lang_fr' %}selected{% endif %}>Français (French)</option>
+        <option value="lang_de" {% if settings.lang == 'lang_de' %}selected{% endif %}>Deutsch (German)</option>
+        <option value="lang_el" {% if settings.lang == 'lang_el' %}selected{% endif %}>Ελληνικά (Greek)</option>
+        <option value="lang_iw" {% if settings.lang == 'lang_iw' %}selected{% endif %}>עברית (Hebrew)</option>
+        <option value="lang_hi" {% if settings.lang == 'lang_hi' %}selected{% endif %}>हिन्दी (Hindi)</option>
+        <option value="lang_hu" {% if settings.lang == 'lang_hu' %}selected{% endif %}>magyar (Hungarian)</option>
+        <option value="lang_is" {% if settings.lang == 'lang_is' %}selected{% endif %}>íslenska (Icelandic)</option>
+        <option value="lang_id" {% if settings.lang == 'lang_id' %}selected{% endif %}>Bahasa Indonesia (Indonesian)</option>
+        <option value="lang_it" {% if settings.lang == 'lang_it' %}selected{% endif %}>italiano (Italian)</option>
+        <option value="lang_ja" {% if settings.lang == 'lang_ja' %}selected{% endif %}>日本語 (Japanese)</option>
+        <option value="lang_ko" {% if settings.lang == 'lang_ko' %}selected{% endif %}>한국어 (Korean)</option>
+        <option value="lang_lv" {% if settings.lang == 'lang_lv' %}selected{% endif %}>latviešu (Latvian)</option>
+        <option value="lang_lt" {% if settings.lang == 'lang_lt' %}selected{% endif %}>lietuvių (Lithuanian)</option>
+        <option value="lang_no" {% if settings.lang == 'lang_no' %}selected{% endif %}>norsk (Norwegian)</option>
+        <option value="lang_fa" {% if settings.lang == 'lang_fa' %}selected{% endif %}>فارسی (Persian)</option>
+        <option value="lang_pl" {% if settings.lang == 'lang_pl' %}selected{% endif %}>polski (Polish)</option>
+        <option value="lang_pt" {% if settings.lang == 'lang_pt' %}selected{% endif %}>português (Portuguese)</option>
+        <option value="lang_ro" {% if settings.lang == 'lang_ro' %}selected{% endif %}>română (Romanian)</option>
+        <option value="lang_ru" {% if settings.lang == 'lang_ru' %}selected{% endif %}>русский (Russian)</option>
+        <option value="lang_sr" {% if settings.lang == 'lang_sr' %}selected{% endif %}>српски (Serbian)</option>
+        <option value="lang_sk" {% if settings.lang == 'lang_sk' %}selected{% endif %}>slovenčina (Slovak)</option>
+        <option value="lang_sl" {% if settings.lang == 'lang_sl' %}selected{% endif %}>slovenščina (Slovenian)</option>
+        <option value="lang_es" {% if settings.lang == 'lang_es' %}selected{% endif %}>español (Spanish)</option>
+        <option value="lang_sw" {% if settings.lang == 'lang_sw' %}selected{% endif %}>Kiswahili (Swahili)</option>
+        <option value="lang_sv" {% if settings.lang == 'lang_sv' %}selected{% endif %}>svenska (Swedish)</option>
+        <option value="lang_th" {% if settings.lang == 'lang_th' %}selected{% endif %}>ไทย (Thai)</option>
+        <option value="lang_tr" {% if settings.lang == 'lang_tr' %}selected{% endif %}>Türkçe (Turkish)</option>
+        <option value="lang_uk" {% if settings.lang == 'lang_uk' %}selected{% endif %}>українська (Ukrainian)</option>
+        <option value="lang_vi" {% if settings.lang == 'lang_vi' %}selected{% endif %}>Tiếng Việt (Vietnamese)</option>
     </select>
     <select class="domain" name="domain">
-        <option value="google.com/search?gl=us" {% if domain == 'google.com/search?gl=us' %}selected{% endif %}>google.com</option>
-        <option value="google.fr/search?gl=fr" {% if domain == 'google.fr/search?gl=fr' %}selected{% endif %}>google.fr</option>
-        <option value="google.ca/search?gl=ca" {% if domain == 'google.ca/search?gl=ca' %}selected{% endif %}>google.ca</option>
-        <option value="google.co.uk/search?gl=uk" {% if domain == 'google.co.uk/search?gl=uk' %}selected{% endif %}>google.co.uk</option>
-        <option value="google.de/search?gl=de" {% if domain == 'google.de/search?gl=de' %}selected{% endif %}>google.de</option>
-        <option value="google.com.au/search?gl=au" {% if domain == 'google.com.au/search?gl=au' %}selected{% endif %}>google.com.au</option>
-        <option value="google.co.in/search?gl=in" {% if domain == 'google.co.in/search?gl=in' %}selected{% endif %}>google.co.in</option>
-        <option value="google.co.jp/search?gl=jp" {% if domain == 'google.co.jp/search?gl=jp' %}selected{% endif %}>google.co.jp</option>
-        <option value="google.co.kr/search?gl=kr" {% if domain == 'google.co.kr/search?gl=kr' %}selected{% endif %}>google.co.kr</option>
-        <option value="google.com.br/search?gl=br" {% if domain == 'google.com.br/search?gl=br' %}selected{% endif %}>google.com.br</option>
+        <option value="google.com/search?gl=us" {% if settings.domain == 'google.com/search?gl=us' %}selected{% endif %}>google.com</option>
+        <option value="google.fr/search?gl=fr" {% if settings.domain == 'google.fr/search?gl=fr' %}selected{% endif %}>google.fr</option>
+        <option value="google.ca/search?gl=ca" {% if settings.domain == 'google.ca/search?gl=ca' %}selected{% endif %}>google.ca</option>
+        <option value="google.co.uk/search?gl=uk" {% if settings.domain == 'google.co.uk/search?gl=uk' %}selected{% endif %}>google.co.uk</option>
+        <option value="google.de/search?gl=de" {% if settings.domain == 'google.de/search?gl=de' %}selected{% endif %}>google.de</option>
+        <option value="google.com.au/search?gl=au" {% if settings.domain == 'google.com.au/search?gl=au' %}selected{% endif %}>google.com.au</option>
+        <option value="google.co.in/search?gl=in" {% if settings.domain == 'google.co.in/search?gl=in' %}selected{% endif %}>google.co.in</option>
+        <option value="google.co.jp/search?gl=jp" {% if settings.domain == 'google.co.jp/search?gl=jp' %}selected{% endif %}>google.co.jp</option>
+        <option value="google.co.kr/search?gl=kr" {% if settings.domain == 'google.co.kr/search?gl=kr' %}selected{% endif %}>google.co.kr</option>
+        <option value="google.com.br/search?gl=br" {% if settings.domain == 'google.com.br/search?gl=br' %}selected{% endif %}>google.com.br</option>
     </select>
     </div>
     </div>
@@ -176,7 +172,7 @@
         </div>
         </div>
         <!-- 'defer' makes script execute only after the whole DOM is parsed. -->
-        {% if javascript == "enabled" %}
+        {% if settings.javascript == "enabled" %}
         <div id="kno_title" data-kno-title="{{ kno_title }}"></div>
         <script defer src="/script.js"></script>
         <script defer src="/menu.js"></script>

--- a/templates/search.html
+++ b/templates/search.html
@@ -2,8 +2,8 @@
 
 {% block body %}
         <link rel="stylesheet" href="{{ url_for('static', filename='css/search.css') }}">
-    {% if css_style %}
-        <link rel="stylesheet" href="./css/{{ css_style }}">
+    {% if settings.theme == "dark_blur" %}
+        <link rel="stylesheet" href="./css/dark_blur_beta.css">
     {% endif %}
     <div class="settings-search-div settings-search-div-search">
         <button class="material-icons-round clickable settings-icon-link settings-icon-link-search">menu</button>
@@ -21,65 +21,65 @@
         </div>
     </div>
     <select class="lang" name="lang">
-        <option value="" {% if lang == '' %}selected{% endif %}>{{ lang_data.settings.any_language }}</option>
-        <option value="lang_en" {% if lang == 'lang_en' %}selected{% endif %}>English</option>
-        <option value="lang_af" {% if lang == 'lang_af' %}selected{% endif %}>Afrikaans</option>
-        <option value="lang_ar" {% if lang == 'lang_ar' %}selected{% endif %}>العربية (Arabic)</option>
-        <option value="lang_hy" {% if lang == 'lang_hy' %}selected{% endif %}>Հայերեն (Armenian)</option>
-        <option value="lang_be" {% if lang == 'lang_be' %}selected{% endif %}>Беларуская (Belarusian)</option>
-        <option value="lang_bg" {% if lang == 'lang_bg' %}selected{% endif %}>български (Bulgarian)</option>
-        <option value="lang_ca" {% if lang == 'lang_ca' %}selected{% endif %}>Català (Catalan)</option>
-        <option value="lang_zh-CN" {% if lang == 'lang_zh-CN' %}selected{% endif %}>中文 (简体) (Chinese Simplified)</option>
-        <option value="lang_zh-TW" {% if lang == 'lang_zh-TW' %}selected{% endif %}>中文 (繁體) (Chinese Traditional)</option>
-        <option value="lang_hr" {% if lang == 'lang_hr' %}selected{% endif %}>Hrvatski (Croatian)</option>
-        <option value="lang_cs" {% if lang == 'lang_cs' %}selected{% endif %}>Čeština (Czech)</option>
-        <option value="lang_da" {% if lang == 'lang_da' %}selected{% endif %}>Dansk (Danish)</option>
-        <option value="lang_nl" {% if lang == 'lang_nl' %}selected{% endif %}>Nederlands (Dutch)</option>
-        <option value="lang_eo" {% if lang == 'lang_eo' %}selected{% endif %}>Esperanto</option>
-        <option value="lang_et" {% if lang == 'lang_et' %}selected{% endif %}>Eesti (Estonian)</option>
-        <option value="lang_tl" {% if lang == 'lang_tl' %}selected{% endif %}>Filipino (Tagalog)</option>
-        <option value="lang_fi" {% if lang == 'lang_fi' %}selected{% endif %}>Suomi (Finnish)</option>
-        <option value="lang_fr" {% if lang == 'lang_fr' %}selected{% endif %}>Français (French)</option>
-        <option value="lang_de" {% if lang == 'lang_de' %}selected{% endif %}>Deutsch (German)</option>
-        <option value="lang_el" {% if lang == 'lang_el' %}selected{% endif %}>Ελληνικά (Greek)</option>
-        <option value="lang_iw" {% if lang == 'lang_iw' %}selected{% endif %}>עברית (Hebrew)</option>
-        <option value="lang_hi" {% if lang == 'lang_hi' %}selected{% endif %}>हिन्दी (Hindi)</option>
-        <option value="lang_hu" {% if lang == 'lang_hu' %}selected{% endif %}>magyar (Hungarian)</option>
-        <option value="lang_is" {% if lang == 'lang_is' %}selected{% endif %}>íslenska (Icelandic)</option>
-        <option value="lang_id" {% if lang == 'lang_id' %}selected{% endif %}>Bahasa Indonesia (Indonesian)</option>
-        <option value="lang_it" {% if lang == 'lang_it' %}selected{% endif %}>italiano (Italian)</option>
-        <option value="lang_ja" {% if lang == 'lang_ja' %}selected{% endif %}>日本語 (Japanese)</option>
-        <option value="lang_ko" {% if lang == 'lang_ko' %}selected{% endif %}>한국어 (Korean)</option>
-        <option value="lang_lv" {% if lang == 'lang_lv' %}selected{% endif %}>latviešu (Latvian)</option>
-        <option value="lang_lt" {% if lang == 'lang_lt' %}selected{% endif %}>lietuvių (Lithuanian)</option>
-        <option value="lang_no" {% if lang == 'lang_no' %}selected{% endif %}>norsk (Norwegian)</option>
-        <option value="lang_fa" {% if lang == 'lang_fa' %}selected{% endif %}>فارسی (Persian)</option>
-        <option value="lang_pl" {% if lang == 'lang_pl' %}selected{% endif %}>polski (Polish)</option>
-        <option value="lang_pt" {% if lang == 'lang_pt' %}selected{% endif %}>português (Portuguese)</option>
-        <option value="lang_ro" {% if lang == 'lang_ro' %}selected{% endif %}>română (Romanian)</option>
-        <option value="lang_ru" {% if lang == 'lang_ru' %}selected{% endif %}>русский (Russian)</option>
-        <option value="lang_sr" {% if lang == 'lang_sr' %}selected{% endif %}>српски (Serbian)</option>
-        <option value="lang_sk" {% if lang == 'lang_sk' %}selected{% endif %}>slovenčina (Slovak)</option>
-        <option value="lang_sl" {% if lang == 'lang_sl' %}selected{% endif %}>slovenščina (Slovenian)</option>
-        <option value="lang_es" {% if lang == 'lang_es' %}selected{% endif %}>español (Spanish)</option>
-        <option value="lang_sw" {% if lang == 'lang_sw' %}selected{% endif %}>Kiswahili (Swahili)</option>
-        <option value="lang_sv" {% if lang == 'lang_sv' %}selected{% endif %}>svenska (Swedish)</option>
-        <option value="lang_th" {% if lang == 'lang_th' %}selected{% endif %}>ไทย (Thai)</option>
-        <option value="lang_tr" {% if lang == 'lang_tr' %}selected{% endif %}>Türkçe (Turkish)</option>
-        <option value="lang_uk" {% if lang == 'lang_uk' %}selected{% endif %}>українська (Ukrainian)</option>
-        <option value="lang_vi" {% if lang == 'lang_vi' %}selected{% endif %}>Tiếng Việt (Vietnamese)</option>
-    </select>
+        <option value="" {% if settings.lang == '' %}selected{% endif %}>{{ lang_data.settings.any_language }}</option>
+        <option value="lang_en" {% if settings.lang == 'lang_en' %}selected{% endif %}>English</option>
+        <option value="lang_af" {% if settings.lang == 'lang_af' %}selected{% endif %}>Afrikaans</option>
+        <option value="lang_ar" {% if settings.lang == 'lang_ar' %}selected{% endif %}>العربية (Arabic)</option>
+        <option value="lang_hy" {% if settings.lang == 'lang_hy' %}selected{% endif %}>Հայերեն (Armenian)</option>
+        <option value="lang_be" {% if settings.lang == 'lang_be' %}selected{% endif %}>Беларуская (Belarusian)</option>
+        <option value="lang_bg" {% if settings.lang == 'lang_bg' %}selected{% endif %}>български (Bulgarian)</option>
+        <option value="lang_ca" {% if settings.lang == 'lang_ca' %}selected{% endif %}>Català (Catalan)</option>
+        <option value="lang_zh-CN" {% if settings.lang == 'lang_zh-CN' %}selected{% endif %}>中文 (简体) (Chinese Simplified)</option>
+        <option value="lang_zh-TW" {% if settings.lang == 'lang_zh-TW' %}selected{% endif %}>中文 (繁體) (Chinese Traditional)</option>
+        <option value="lang_hr" {% if settings.lang == 'lang_hr' %}selected{% endif %}>Hrvatski (Croatian)</option>
+        <option value="lang_cs" {% if settings.lang == 'lang_cs' %}selected{% endif %}>Čeština (Czech)</option>
+        <option value="lang_da" {% if settings.lang == 'lang_da' %}selected{% endif %}>Dansk (Danish)</option>
+        <option value="lang_nl" {% if settings.lang == 'lang_nl' %}selected{% endif %}>Nederlands (Dutch)</option>
+        <option value="lang_eo" {% if settings.lang == 'lang_eo' %}selected{% endif %}>Esperanto</option>
+        <option value="lang_et" {% if settings.lang == 'lang_et' %}selected{% endif %}>Eesti (Estonian)</option>
+        <option value="lang_tl" {% if settings.lang == 'lang_tl' %}selected{% endif %}>Filipino (Tagalog)</option>
+        <option value="lang_fi" {% if settings.lang == 'lang_fi' %}selected{% endif %}>Suomi (Finnish)</option>
+        <option value="lang_fr" {% if settings.lang == 'lang_fr' %}selected{% endif %}>Français (French)</option>
+        <option value="lang_de" {% if settings.lang == 'lang_de' %}selected{% endif %}>Deutsch (German)</option>
+        <option value="lang_el" {% if settings.lang == 'lang_el' %}selected{% endif %}>Ελληνικά (Greek)</option>
+        <option value="lang_iw" {% if settings.lang == 'lang_iw' %}selected{% endif %}>עברית (Hebrew)</option>
+        <option value="lang_hi" {% if settings.lang == 'lang_hi' %}selected{% endif %}>हिन्दी (Hindi)</option>
+        <option value="lang_hu" {% if settings.lang == 'lang_hu' %}selected{% endif %}>magyar (Hungarian)</option>
+        <option value="lang_is" {% if settings.lang == 'lang_is' %}selected{% endif %}>íslenska (Icelandic)</option>
+        <option value="lang_id" {% if settings.lang == 'lang_id' %}selected{% endif %}>Bahasa Indonesia (Indonesian)</option>
+        <option value="lang_it" {% if settings.lang == 'lang_it' %}selected{% endif %}>italiano (Italian)</option>
+        <option value="lang_ja" {% if settings.lang == 'lang_ja' %}selected{% endif %}>日本語 (Japanese)</option>
+        <option value="lang_ko" {% if settings.lang == 'lang_ko' %}selected{% endif %}>한국어 (Korean)</option>
+        <option value="lang_lv" {% if settings.lang == 'lang_lv' %}selected{% endif %}>latviešu (Latvian)</option>
+        <option value="lang_lt" {% if settings.lang == 'lang_lt' %}selected{% endif %}>lietuvių (Lithuanian)</option>
+        <option value="lang_no" {% if settings.lang == 'lang_no' %}selected{% endif %}>norsk (Norwegian)</option>
+        <option value="lang_fa" {% if settings.lang == 'lang_fa' %}selected{% endif %}>فارسی (Persian)</option>
+        <option value="lang_pl" {% if settings.lang == 'lang_pl' %}selected{% endif %}>polski (Polish)</option>
+        <option value="lang_pt" {% if settings.lang == 'lang_pt' %}selected{% endif %}>português (Portuguese)</option>
+        <option value="lang_ro" {% if settings.lang == 'lang_ro' %}selected{% endif %}>română (Romanian)</option>
+        <option value="lang_ru" {% if settings.lang == 'lang_ru' %}selected{% endif %}>русский (Russian)</option>
+        <option value="lang_sr" {% if settings.lang == 'lang_sr' %}selected{% endif %}>српски (Serbian)</option>
+        <option value="lang_sk" {% if settings.lang == 'lang_sk' %}selected{% endif %}>slovenčina (Slovak)</option>
+        <option value="lang_sl" {% if settings.lang == 'lang_sl' %}selected{% endif %}>slovenščina (Slovenian)</option>
+        <option value="lang_es" {% if settings.lang == 'lang_es' %}selected{% endif %}>español (Spanish)</option>
+        <option value="lang_sw" {% if settings.lang == 'lang_sw' %}selected{% endif %}>Kiswahili (Swahili)</option>
+        <option value="lang_sv" {% if settings.lang == 'lang_sv' %}selected{% endif %}>svenska (Swedish)</option>
+        <option value="lang_th" {% if settings.lang == 'lang_th' %}selected{% endif %}>ไทย (Thai)</option>
+        <option value="lang_tr" {% if settings.lang == 'lang_tr' %}selected{% endif %}>Türkçe (Turkish)</option>
+        <option value="lang_uk" {% if settings.lang == 'lang_uk' %}selected{% endif %}>українська (Ukrainian)</option>
+        <option value="lang_vi" {% if settings.lang == 'lang_vi' %}selected{% endif %}>Tiếng Việt (Vietnamese)</option>
+  </select>
     <select class="domain" name="domain">
-        <option value="google.com/search?gl=us" {% if domain == 'google.com/search?gl=us' %}selected{% endif %}>google.com</option>
-        <option value="google.fr/search?gl=fr" {% if domain == 'google.fr/search?gl=fr' %}selected{% endif %}>google.fr</option>
-        <option value="google.ca/search?gl=ca" {% if domain == 'google.ca/search?gl=ca' %}selected{% endif %}>google.ca</option>
-        <option value="google.co.uk/search?gl=uk" {% if domain == 'google.co.uk/search?gl=uk' %}selected{% endif %}>google.co.uk</option>
-        <option value="google.de/search?gl=de" {% if domain == 'google.de/search?gl=de' %}selected{% endif %}>google.de</option>
-        <option value="google.com.au/search?gl=au" {% if domain == 'google.com.au/search?gl=au' %}selected{% endif %}>google.com.au</option>
-        <option value="google.co.in/search?gl=in" {% if domain == 'google.co.in/search?gl=in' %}selected{% endif %}>google.co.in</option>
-        <option value="google.co.jp/search?gl=jp" {% if domain == 'google.co.jp/search?gl=jp' %}selected{% endif %}>google.co.jp</option>
-        <option value="google.co.kr/search?gl=kr" {% if domain == 'google.co.kr/search?gl=kr' %}selected{% endif %}>google.co.kr</option>
-        <option value="google.com.br/search?gl=br" {% if domain == 'google.com.br/search?gl=br' %}selected{% endif %}>google.com.br</option>
+        <option value="google.com/search?gl=us" {% if settings.domain == 'google.com/search?gl=us' %}selected{% endif %}>google.com</option>
+        <option value="google.fr/search?gl=fr" {% if settings.domain == 'google.fr/search?gl=fr' %}selected{% endif %}>google.fr</option>
+        <option value="google.ca/search?gl=ca" {% if settings.domain == 'google.ca/search?gl=ca' %}selected{% endif %}>google.ca</option>
+        <option value="google.co.uk/search?gl=uk" {% if settings.domain == 'google.co.uk/search?gl=uk' %}selected{% endif %}>google.co.uk</option>
+        <option value="google.de/search?gl=de" {% if settings.domain == 'google.de/search?gl=de' %}selected{% endif %}>google.de</option>
+        <option value="google.com.au/search?gl=au" {% if settings.domain == 'google.com.au/search?gl=au' %}selected{% endif %}>google.com.au</option>
+        <option value="google.co.in/search?gl=in" {% if settings.domain == 'google.co.in/search?gl=in' %}selected{% endif %}>google.co.in</option>
+        <option value="google.co.jp/search?gl=jp" {% if settings.domain == 'google.co.jp/search?gl=jp' %}selected{% endif %}>google.co.jp</option>
+        <option value="google.co.kr/search?gl=kr" {% if settings.domain == 'google.co.kr/search?gl=kr' %}selected{% endif %}>google.co.kr</option>
+        <option value="google.com.br/search?gl=br" {% if settings.domain == 'google.com.br/search?gl=br' %}selected{% endif %}>google.com.br</option>
     </select>
     </div>
     </div>
@@ -98,7 +98,7 @@
             <button name="t" value="text" type="submit">{{ lang_data.search_buttons.search_text }}</button>
             <button name="t" value="image" type="submit">{{ lang_data.search_buttons.search_images }}</button>
         </div>
-        {% if javascript == "enabled" %}
+        {% if settings.javascript == "enabled" %}
         <script defer src="/script.js"></script>
         <script defer src="/menu.js"></script>
         <script defer src="/cookies.js"></script>

--- a/templates/settings.html
+++ b/templates/settings.html
@@ -24,120 +24,120 @@
         <div class="settings-row">
         <p>{{ lang_data.settings.preferred_language }}</p>
         <select id="lang" name="lang">
-            <option value="" {% if lang == '' %}selected{% endif %}>{{ lang_data.settings.any_language }}</option>
-            <option value="lang_en" {% if lang == 'lang_en' %}selected{% endif %}>English</option>
-            <option value="lang_af" {% if lang == 'lang_af' %}selected{% endif %}>Afrikaans</option>
-            <option value="lang_ar" {% if lang == 'lang_ar' %}selected{% endif %}>العربية (Arabic)</option>
-            <option value="lang_hy" {% if lang == 'lang_hy' %}selected{% endif %}>Հայերեն (Armenian)</option>
-            <option value="lang_be" {% if lang == 'lang_be' %}selected{% endif %}>Беларуская (Belarusian)</option>
-            <option value="lang_bg" {% if lang == 'lang_bg' %}selected{% endif %}>български (Bulgarian)</option>
-            <option value="lang_ca" {% if lang == 'lang_ca' %}selected{% endif %}>Català (Catalan)</option>
-            <option value="lang_zh-CN" {% if lang == 'lang_zh-CN' %}selected{% endif %}>中文 (简体) (Chinese Simplified)</option>
-            <option value="lang_zh-TW" {% if lang == 'lang_zh-TW' %}selected{% endif %}>中文 (繁體) (Chinese Traditional)</option>
-            <option value="lang_hr" {% if lang == 'lang_hr' %}selected{% endif %}>Hrvatski (Croatian)</option>
-            <option value="lang_cs" {% if lang == 'lang_cs' %}selected{% endif %}>Čeština (Czech)</option>
-            <option value="lang_da" {% if lang == 'lang_da' %}selected{% endif %}>Dansk (Danish)</option>
-            <option value="lang_nl" {% if lang == 'lang_nl' %}selected{% endif %}>Nederlands (Dutch)</option>
-            <option value="lang_eo" {% if lang == 'lang_eo' %}selected{% endif %}>Esperanto</option>
-            <option value="lang_et" {% if lang == 'lang_et' %}selected{% endif %}>Eesti (Estonian)</option>
-            <option value="lang_tl" {% if lang == 'lang_tl' %}selected{% endif %}>Filipino (Tagalog)</option>
-            <option value="lang_fi" {% if lang == 'lang_fi' %}selected{% endif %}>Suomi (Finnish)</option>
-            <option value="lang_fr" {% if lang == 'lang_fr' %}selected{% endif %}>Français (French)</option>
-            <option value="lang_de" {% if lang == 'lang_de' %}selected{% endif %}>Deutsch (German)</option>
-            <option value="lang_el" {% if lang == 'lang_el' %}selected{% endif %}>Ελληνικά (Greek)</option>
-            <option value="lang_iw" {% if lang == 'lang_iw' %}selected{% endif %}>עברית (Hebrew)</option>
-            <option value="lang_hi" {% if lang == 'lang_hi' %}selected{% endif %}>हिन्दी (Hindi)</option>
-            <option value="lang_hu" {% if lang == 'lang_hu' %}selected{% endif %}>magyar (Hungarian)</option>
-            <option value="lang_is" {% if lang == 'lang_is' %}selected{% endif %}>íslenska (Icelandic)</option>
-            <option value="lang_id" {% if lang == 'lang_id' %}selected{% endif %}>Bahasa Indonesia (Indonesian)</option>
-            <option value="lang_it" {% if lang == 'lang_it' %}selected{% endif %}>italiano (Italian)</option>
-            <option value="lang_ja" {% if lang == 'lang_ja' %}selected{% endif %}>日本語 (Japanese)</option>
-            <option value="lang_ko" {% if lang == 'lang_ko' %}selected{% endif %}>한국어 (Korean)</option>
-            <option value="lang_lv" {% if lang == 'lang_lv' %}selected{% endif %}>latviešu (Latvian)</option>
-            <option value="lang_lt" {% if lang == 'lang_lt' %}selected{% endif %}>lietuvių (Lithuanian)</option>
-            <option value="lang_no" {% if lang == 'lang_no' %}selected{% endif %}>norsk (Norwegian)</option>
-            <option value="lang_fa" {% if lang == 'lang_fa' %}selected{% endif %}>فارسی (Persian)</option>
-            <option value="lang_pl" {% if lang == 'lang_pl' %}selected{% endif %}>polski (Polish)</option>
-            <option value="lang_pt" {% if lang == 'lang_pt' %}selected{% endif %}>português (Portuguese)</option>
-            <option value="lang_ro" {% if lang == 'lang_ro' %}selected{% endif %}>română (Romanian)</option>
-            <option value="lang_ru" {% if lang == 'lang_ru' %}selected{% endif %}>русский (Russian)</option>
-            <option value="lang_sr" {% if lang == 'lang_sr' %}selected{% endif %}>српски (Serbian)</option>
-            <option value="lang_sk" {% if lang == 'lang_sk' %}selected{% endif %}>slovenčina (Slovak)</option>
-            <option value="lang_sl" {% if lang == 'lang_sl' %}selected{% endif %}>slovenščina (Slovenian)</option>
-            <option value="lang_es" {% if lang == 'lang_es' %}selected{% endif %}>español (Spanish)</option>
-            <option value="lang_sw" {% if lang == 'lang_sw' %}selected{% endif %}>Kiswahili (Swahili)</option>
-            <option value="lang_sv" {% if lang == 'lang_sv' %}selected{% endif %}>svenska (Swedish)</option>
-            <option value="lang_th" {% if lang == 'lang_th' %}selected{% endif %}>ไทย (Thai)</option>
-            <option value="lang_tr" {% if lang == 'lang_tr' %}selected{% endif %}>Türkçe (Turkish)</option>
-            <option value="lang_uk" {% if lang == 'lang_uk' %}selected{% endif %}>українська (Ukrainian)</option>
-            <option value="lang_vi" {% if lang == 'lang_vi' %}selected{% endif %}>Tiếng Việt (Vietnamese)</option>
+            <option value="" {% if settings.lang == '' %}selected{% endif %}>{{ lang_data.settings.any_language }}</option>
+            <option value="lang_en" {% if settings.lang == 'lang_en' %}selected{% endif %}>English</option>
+            <option value="lang_af" {% if settings.lang == 'lang_af' %}selected{% endif %}>Afrikaans</option>
+            <option value="lang_ar" {% if settings.lang == 'lang_ar' %}selected{% endif %}>العربية (Arabic)</option>
+            <option value="lang_hy" {% if settings.lang == 'lang_hy' %}selected{% endif %}>Հայերեն (Armenian)</option>
+            <option value="lang_be" {% if settings.lang == 'lang_be' %}selected{% endif %}>Беларуская (Belarusian)</option>
+            <option value="lang_bg" {% if settings.lang == 'lang_bg' %}selected{% endif %}>български (Bulgarian)</option>
+            <option value="lang_ca" {% if settings.lang == 'lang_ca' %}selected{% endif %}>Català (Catalan)</option>
+            <option value="lang_zh-CN" {% if settings.lang == 'lang_zh-CN' %}selected{% endif %}>中文 (简体) (Chinese Simplified)</option>
+            <option value="lang_zh-TW" {% if settings.lang == 'lang_zh-TW' %}selected{% endif %}>中文 (繁體) (Chinese Traditional)</option>
+            <option value="lang_hr" {% if settings.lang == 'lang_hr' %}selected{% endif %}>Hrvatski (Croatian)</option>
+            <option value="lang_cs" {% if settings.lang == 'lang_cs' %}selected{% endif %}>Čeština (Czech)</option>
+            <option value="lang_da" {% if settings.lang == 'lang_da' %}selected{% endif %}>Dansk (Danish)</option>
+            <option value="lang_nl" {% if settings.lang == 'lang_nl' %}selected{% endif %}>Nederlands (Dutch)</option>
+            <option value="lang_eo" {% if settings.lang == 'lang_eo' %}selected{% endif %}>Esperanto</option>
+            <option value="lang_et" {% if settings.lang == 'lang_et' %}selected{% endif %}>Eesti (Estonian)</option>
+            <option value="lang_tl" {% if settings.lang == 'lang_tl' %}selected{% endif %}>Filipino (Tagalog)</option>
+            <option value="lang_fi" {% if settings.lang == 'lang_fi' %}selected{% endif %}>Suomi (Finnish)</option>
+            <option value="lang_fr" {% if settings.lang == 'lang_fr' %}selected{% endif %}>Français (French)</option>
+            <option value="lang_de" {% if settings.lang == 'lang_de' %}selected{% endif %}>Deutsch (German)</option>
+            <option value="lang_el" {% if settings.lang == 'lang_el' %}selected{% endif %}>Ελληνικά (Greek)</option>
+            <option value="lang_iw" {% if settings.lang == 'lang_iw' %}selected{% endif %}>עברית (Hebrew)</option>
+            <option value="lang_hi" {% if settings.lang == 'lang_hi' %}selected{% endif %}>हिन्दी (Hindi)</option>
+            <option value="lang_hu" {% if settings.lang == 'lang_hu' %}selected{% endif %}>magyar (Hungarian)</option>
+            <option value="lang_is" {% if settings.lang == 'lang_is' %}selected{% endif %}>íslenska (Icelandic)</option>
+            <option value="lang_id" {% if settings.lang == 'lang_id' %}selected{% endif %}>Bahasa Indonesia (Indonesian)</option>
+            <option value="lang_it" {% if settings.lang == 'lang_it' %}selected{% endif %}>italiano (Italian)</option>
+            <option value="lang_ja" {% if settings.lang == 'lang_ja' %}selected{% endif %}>日本語 (Japanese)</option>
+            <option value="lang_ko" {% if settings.lang == 'lang_ko' %}selected{% endif %}>한국어 (Korean)</option>
+            <option value="lang_lv" {% if settings.lang == 'lang_lv' %}selected{% endif %}>latviešu (Latvian)</option>
+            <option value="lang_lt" {% if settings.lang == 'lang_lt' %}selected{% endif %}>lietuvių (Lithuanian)</option>
+            <option value="lang_no" {% if settings.lang == 'lang_no' %}selected{% endif %}>norsk (Norwegian)</option>
+            <option value="lang_fa" {% if settings.lang == 'lang_fa' %}selected{% endif %}>فارسی (Persian)</option>
+            <option value="lang_pl" {% if settings.lang == 'lang_pl' %}selected{% endif %}>polski (Polish)</option>
+            <option value="lang_pt" {% if settings.lang == 'lang_pt' %}selected{% endif %}>português (Portuguese)</option>
+            <option value="lang_ro" {% if settings.lang == 'lang_ro' %}selected{% endif %}>română (Romanian)</option>
+            <option value="lang_ru" {% if settings.lang == 'lang_ru' %}selected{% endif %}>русский (Russian)</option>
+            <option value="lang_sr" {% if settings.lang == 'lang_sr' %}selected{% endif %}>српски (Serbian)</option>
+            <option value="lang_sk" {% if settings.lang == 'lang_sk' %}selected{% endif %}>slovenčina (Slovak)</option>
+            <option value="lang_sl" {% if settings.lang == 'lang_sl' %}selected{% endif %}>slovenščina (Slovenian)</option>
+            <option value="lang_es" {% if settings.lang == 'lang_es' %}selected{% endif %}>español (Spanish)</option>
+            <option value="lang_sw" {% if settings.lang == 'lang_sw' %}selected{% endif %}>Kiswahili (Swahili)</option>
+            <option value="lang_sv" {% if settings.lang == 'lang_sv' %}selected{% endif %}>svenska (Swedish)</option>
+            <option value="lang_th" {% if settings.lang == 'lang_th' %}selected{% endif %}>ไทย (Thai)</option>
+            <option value="lang_tr" {% if settings.lang == 'lang_tr' %}selected{% endif %}>Türkçe (Turkish)</option>
+            <option value="lang_uk" {% if settings.lang == 'lang_uk' %}selected{% endif %}>українська (Ukrainian)</option>
+            <option value="lang_vi" {% if settings.lang == 'lang_vi' %}selected{% endif %}>Tiếng Việt (Vietnamese)</option>
         </select>
         </div>
         <div class="settings-row">
         <p>{{ lang_data.settings.preferredux_language }}</p>
         <select id="ux_lang" name="ux_lang">
-            <option value="english" {% if ux_lang == 'english' %}selected{% endif %}>English</option>
-            <option value="danish" {% if ux_lang == 'danish' %}selected{% endif %}>Danish (Dansk)</option>
-            <option value="dutch" {% if ux_lang == 'dutch' %}selected{% endif %}>Dutch (Nederlands)</option>
-            <option value="french" {% if ux_lang == 'french' %}selected{% endif %}>French (Français)</option>
-            <option value="french_canadian" {% if ux_lang == 'french_canadian' %}selected{% endif %}>French Canadian (Français canadien)</option>
-            <option value="german" {% if ux_lang == 'german' %}selected{% endif %}>German (Deutsch)</option>
-            <option value="greek" {% if ux_lang == 'greek' %}selected{% endif %}>Greek (Ελληνικά)</option>
-            <option value="italian" {% if ux_lang == 'italian' %}selected{% endif %}>Italian (Italiano)</option>
-            <option value="japanese" {% if ux_lang == 'japanese' %}selected{% endif %}>Japanese (日本語)</option>
-            <option value="korean" {% if ux_lang == 'korean' %}selected{% endif %}>Korean (한국어)</option>
-            <option value="mandarin_chinese" {% if ux_lang == 'mandarin_chinese' %}selected{% endif %}>Mandarin Chinese (普通话 or 中文)</option>
-            <option value="norwegian" {% if ux_lang == 'norwegian' %}selected{% endif %}>Norwegian (Norsk)</option>
-            <option value="polish" {% if ux_lang == 'polish' %}selected{% endif %}>Polish (Polski)</option>
-            <option value="portuguese" {% if ux_lang == 'portuguese' %}selected{% endif %}>Portuguese (Português)</option>
-            <option value="russian" {% if ux_lang == 'russian' %}selected{% endif %}>Russian (Русский)</option>
-            <option value="spanish" {% if ux_lang == 'spanish' %}selected{% endif %}>Spanish (Español)</option>
-            <option value="swedish" {% if ux_lang == 'swedish' %}selected{% endif %}>Swedish (Svenska)</option>
-            <option value="turkish" {% if ux_lang == 'turkish' %}selected{% endif %}>Turkish (Türkçe)</option>
-            <option value="ukrainian" {% if ux_lang == 'ukrainian' %}selected{% endif %}>Ukrainian (Українська)</option>
+            <option value="english" {% if settings.ux_lang == 'english' %}selected{% endif %}>English</option>
+            <option value="danish" {% if settings.ux_lang == 'danish' %}selected{% endif %}>Danish (Dansk)</option>
+            <option value="dutch" {% if settings.ux_lang == 'dutch' %}selected{% endif %}>Dutch (Nederlands)</option>
+            <option value="french" {% if settings.ux_lang == 'french' %}selected{% endif %}>French (Français)</option>
+            <option value="french_canadian" {% if settings.ux_lang == 'french_canadian' %}selected{% endif %}>French Canadian (Français canadien)</option>
+            <option value="german" {% if settings.ux_lang == 'german' %}selected{% endif %}>German (Deutsch)</option>
+            <option value="greek" {% if settings.ux_lang == 'greek' %}selected{% endif %}>Greek (Ελληνικά)</option>
+            <option value="italian" {% if settings.ux_lang == 'italian' %}selected{% endif %}>Italian (Italiano)</option>
+            <option value="japanese" {% if settings.ux_lang == 'japanese' %}selected{% endif %}>Japanese (日本語)</option>
+            <option value="korean" {% if settings.ux_lang == 'korean' %}selected{% endif %}>Korean (한국어)</option>
+            <option value="mandarin_chinese" {% if settings.ux_lang == 'mandarin_chinese' %}selected{% endif %}>Mandarin Chinese (普通话 or 中文)</option>
+            <option value="norwegian" {% if settings.ux_lang == 'norwegian' %}selected{% endif %}>Norwegian (Norsk)</option>
+            <option value="polish" {% if settings.ux_lang == 'polish' %}selected{% endif %}>Polish (Polski)</option>
+            <option value="portuguese" {% if settings.ux_lang == 'portuguese' %}selected{% endif %}>Portuguese (Português)</option>
+            <option value="russian" {% if settings.ux_lang == 'russian' %}selected{% endif %}>Russian (Русский)</option>
+            <option value="spanish" {% if settings.ux_lang == 'spanish' %}selected{% endif %}>Spanish (Español)</option>
+            <option value="swedish" {% if settings.ux_lang == 'swedish' %}selected{% endif %}>Swedish (Svenska)</option>
+            <option value="turkish" {% if settings.ux_lang == 'turkish' %}selected{% endif %}>Turkish (Türkçe)</option>
+            <option value="ukrainian" {% if settings.ux_lang == 'ukrainian' %}selected{% endif %}>Ukrainian (Українська)</option>
         </select>            
         </div>
     <div class="settings-row">
         <p>{{ lang_data.settings.google_domain }}</p>
         <select id="domain" name="domain">
-            <option value="google.com/search?gl=us" {% if domain == 'google.com/search?gl=us' %}selected{% endif %}>google.com</option>
-            <option value="google.fr/search?gl=fr" {% if domain == 'google.fr/search?gl=fr' %}selected{% endif %}>google.fr</option>
-            <option value="google.ca/search?gl=ca" {% if domain == 'google.ca/search?gl=ca' %}selected{% endif %}>google.ca</option>
-            <option value="google.co.uk/search?gl=uk" {% if domain == 'google.co.uk/search?gl=uk' %}selected{% endif %}>google.co.uk</option>
-            <option value="google.de/search?gl=de" {% if domain == 'google.de/search?gl=de' %}selected{% endif %}>google.de</option>
-            <option value="google.com.au/search?gl=au" {% if domain == 'google.com.au/search?gl=au' %}selected{% endif %}>google.com.au</option>
-            <option value="google.co.in/search?gl=in" {% if domain == 'google.co.in/search?gl=in' %}selected{% endif %}>google.co.in</option>
-            <option value="google.co.jp/search?gl=jp" {% if domain == 'google.co.jp/search?gl=jp' %}selected{% endif %}>google.co.jp</option>
-            <option value="google.co.kr/search?gl=kr" {% if domain == 'google.co.kr/search?gl=kr' %}selected{% endif %}>google.co.kr</option>
-            <option value="google.com.br/search?gl=br" {% if domain == 'google.com.br/search?gl=br' %}selected{% endif %}>google.com.br</option>
+            <option value="google.com/search?gl=us" {% if settings.domain == 'google.com/search?gl=us' %}selected{% endif %}>google.com</option>
+            <option value="google.fr/search?gl=fr" {% if settings.domain == 'google.fr/search?gl=fr' %}selected{% endif %}>google.fr</option>
+            <option value="google.ca/search?gl=ca" {% if settings.domain == 'google.ca/search?gl=ca' %}selected{% endif %}>google.ca</option>
+            <option value="google.co.uk/search?gl=uk" {% if settings.domain == 'google.co.uk/search?gl=uk' %}selected{% endif %}>google.co.uk</option>
+            <option value="google.de/search?gl=de" {% if settings.domain == 'google.de/search?gl=de' %}selected{% endif %}>google.de</option>
+            <option value="google.com.au/search?gl=au" {% if settings.domain == 'google.com.au/search?gl=au' %}selected{% endif %}>google.com.au</option>
+            <option value="google.co.in/search?gl=in" {% if settings.domain == 'google.co.in/search?gl=in' %}selected{% endif %}>google.co.in</option>
+            <option value="google.co.jp/search?gl=jp" {% if settings.domain == 'google.co.jp/search?gl=jp' %}selected{% endif %}>google.co.jp</option>
+            <option value="google.co.kr/search?gl=kr" {% if settings.domain == 'google.co.kr/search?gl=kr' %}selected{% endif %}>google.co.kr</option>
+            <option value="google.com.br/search?gl=br" {% if settings.domain == 'google.com.br/search?gl=br' %}selected{% endif %}>google.com.br</option>
         </select>
     </div>        
     <div class="settings-row">
         <p>{{ lang_data.settings.safe_search }}</p>
         <select id="safe" name="safe">
-            <option value="active" {% if safe == 'active' %}selected{% endif %}>{{ lang_data.settings.safe_search }} {{ lang_data.settings.on }}</option>
-            <option value="" {% if safe == '' %}selected{% endif %}>{{ lang_data.settings.safe_search }} {{ lang_data.settings.off }}</option>
+            <option value="active" {% if settings.safe == 'active' %}selected{% endif %}>{{ lang_data.settings.safe_search }} {{ lang_data.settings.on }}</option>
+            <option value="" {% if settings.safe == '' %}selected{% endif %}>{{ lang_data.settings.safe_search }} {{ lang_data.settings.off }}</option>
         </select>
     </div>
     <div class="settings-row">
         <p>{{ lang_data.settings.open_links_new_tab }}</p>
         <select id="open-new-tab" name="new_tab">
-            <option value="" {% if new_tab == '' %}selected{% endif %}>New Tab Off</option>
-            <option value="active" {% if new_tab == 'active' %}selected{% endif %}>New Tab On</option>
+            <option value="" {% if settings.new_tab == '' %}selected{% endif %}>New Tab Off</option>
+            <option value="active" {% if settings.new_tab == 'active' %}selected{% endif %}>New Tab On</option>
         </select>
     </div>
     <div class="settings-row">
         <p>{{ lang_data.settings.disable_javascript }}</p>
         <select id="javascript-setting" name="javascript">
-            <option value="enabled" {% if javascript == 'enabled' %}selected{% endif %}>JavaScript Enabled</option>
-            <option value="" {% if javascript == '' %}selected{% endif %}>JavaScript Disabled</option>
+            <option value="enabled" {% if settings.javascript == 'enabled' %}selected{% endif %}>JavaScript Enabled</option>
+            <option value="" {% if settings.javascript == '' %}selected{% endif %}>JavaScript Disabled</option>
         </select>
     </div>
     <div class="settings-row settings-row2">
         <p class="font-hide">|</p>
         <button class="save save-settings-page" type="submit">{{ lang_data.settings.save_settings }}</button>
     </div>
-        {% if javascript == "enabled" %}
+        {% if settings.javascript == "enabled" %}
         <script defer src="/cookies-settings-version.js"></script>
         <script defer src="/menu.js"></script>
         <script defer src="/cookies.js"></script>

--- a/templates/torrents.html
+++ b/templates/torrents.html
@@ -22,7 +22,7 @@
         <option value="software" {% if cat == "software" %} selected {% endif %}>Software</option>
         <option value="anime" {% if cat == "anime" %} selected {% endif %}>Anime</option>
         <option value="music" {% if cat == "music" %} selected {% endif %}>Music</option>
-        {% if safesearch != "active" %}
+        {% if settings.safe != "active" %}
           <option value="xxx" {% if cat == "xxx" %} selected {% endif %}>XXX (18+)</option>
         {% endif %}
       </select>

--- a/templates/videos.html
+++ b/templates/videos.html
@@ -11,7 +11,7 @@
 	</img></a>
         </div>
             <div class="results">
-            <a {% if new_tab == "active" %} target="_blank" {% endif %} href="{{ result[0] }}"><h3 class="video_title" href="{{ result[0] }}">{{ result[1] }}</h3></a>
+            <a {% if settings.new_tab == "active" %} target="_blank" {% endif %} href="{{ result[0] }}"><h3 class="video_title" href="{{ result[0] }}">{{ result[1] }}</h3></a>
             <p class="stats">{{ result[3] }} • {{ result[2] }}</p>
             <p class="publish__info">{{ result[5] }} <span class="pipe">|</span> {{ result[4] }}</p>
         </div>


### PR DESCRIPTION
This PR moves all the settings into a single class.
The reason behind it is that if you currently want to add another setting, you'll have to change several files, which can be very time consuming.
The way that the `render_template`s are formatted at the end of each function isn't very readable, so this helps to reduce its size.
If you've got no knowledge of the codebase, and are reading through any of the template files, this PR helps in making things more readable, as all settings begin with `setting.`.
Also, if there's ever any vulnerabilities that come from the cookies, it'll now be 10x easier to perform validation on the cookies.