### PR TITLE
Improve image page design

### DIFF
--- a/src/images.py
+++ b/src/images.py
@@ -28,8 +28,8 @@ def imageResults(query) -> Response:
     api = args.get("api", "false")
 
     p = args.get('p', '1')
-    # if not p.isdigit():
-    #     return redirect('/search')
+    if not p.isdigit():
+        return redirect('/search')
 
     # returns 1 if active, else 0
     safe_search = int(settings.safe == "active")
@@ -53,36 +53,6 @@ def imageResults(query) -> Response:
         image['source'] = urlparse(image['url']).netloc
 
         results.append(image)
-
-    # try:
-    #     # get 'img' ellements
-    #     elements = json_data["data"]["result"]["items"]
-    #     # get source urls
-    #     image_sources = [item["media_preview"] for item in elements]
-    #     media_fullsize = [item["media_fullsize"] for item in elements]
-    # except:
-    #     return redirect('/search')
-    #
-    # # get alt tags
-    # image_alts = [item["title"] for item in elements]
-    #
-    # # generate results
-    # images = [f"/img_proxy?url={quote(img_src)}" for img_src in image_sources]
-    # media_fullsize_images = [f"/img_proxy?url={quote(img_src)}" for img_src in media_fullsize]
-    #
-    # # source urls
-    # links = [item["url"] for item in elements]
-    #
-    # # list
-    # results = []
-    # for image, link, image_alt, image_fullsize in zip(images, links, image_alts, media_fullsize_images):
-    #     results.append({
-    #         "image": image,
-    #         "link": link,
-    #         "image_title": image_alt,
-    #         "image_full": image_fullsize,
-    #         "source": urlparse(link).netloc,
-    #     })
 
     # calc. time spent
     end_time = time.time()

--- a/src/images.py
+++ b/src/images.py
@@ -4,7 +4,7 @@ from _config import *
 from flask import request, render_template, jsonify, Response, redirect
 import time
 import json
-from urllib.parse import quote
+from urllib.parse import quote, urlparse
 import requests
 import random
 
@@ -28,8 +28,8 @@ def imageResults(query) -> Response:
     api = args.get("api", "false")
 
     p = args.get('p', '1')
-    if not p.isdigit():
-        return redirect('/search')
+    # if not p.isdigit():
+    #     return redirect('/search')
 
     # returns 1 if active, else 0
     safe_search = int(settings.safe == "active")
@@ -40,29 +40,49 @@ def imageResults(query) -> Response:
     response = requests.get(f"https://api.qwant.com/v3/search/images?t=images&q={quote(query)}&count=50&locale=en_CA&offset={p}&device=desktop&tgp=2&safesearch={safe_search}", headers=headers)
     json_data = response.json()
 
-    try:
-        # get 'img' ellements
-        elements = json_data["data"]["result"]["items"]
-        # get source urls
-        image_sources = [item["media_preview"] for item in elements]
-        media_fullsize = [item["media_fullsize"] for item in elements]
-    except:
+    # Get all the images from the response, while avoiding any errors.
+    images = json_data.get("data", {}).get("result", {}).get("items", None)
+    if images is None:
         return redirect('/search')
 
-    # get alt tags
-    image_alts = [item["title"] for item in elements]
-
-    # generate results
-    images = [f"/img_proxy?url={quote(img_src)}" for img_src in image_sources]
-    media_fullsize_images = [f"/img_proxy?url={quote(img_src)}" for img_src in media_fullsize]
-
-    # source urls
-    links = [item["url"] for item in elements]
-
-    # list
     results = []
-    for image, link, image_alt, image_fullsize in zip(images, links, image_alts, media_fullsize_images):
-        results.append((image, link, image_alt, image_fullsize))
+    for image in images:
+        image['thumb_proxy'] = f"/img_proxy?url={quote(image['thumbnail'])}"
+
+        # Get domain name
+        image['source'] = urlparse(image['url']).netloc
+
+        results.append(image)
+
+    # try:
+    #     # get 'img' ellements
+    #     elements = json_data["data"]["result"]["items"]
+    #     # get source urls
+    #     image_sources = [item["media_preview"] for item in elements]
+    #     media_fullsize = [item["media_fullsize"] for item in elements]
+    # except:
+    #     return redirect('/search')
+    #
+    # # get alt tags
+    # image_alts = [item["title"] for item in elements]
+    #
+    # # generate results
+    # images = [f"/img_proxy?url={quote(img_src)}" for img_src in image_sources]
+    # media_fullsize_images = [f"/img_proxy?url={quote(img_src)}" for img_src in media_fullsize]
+    #
+    # # source urls
+    # links = [item["url"] for item in elements]
+    #
+    # # list
+    # results = []
+    # for image, link, image_alt, image_fullsize in zip(images, links, image_alts, media_fullsize_images):
+    #     results.append({
+    #         "image": image,
+    #         "link": link,
+    #         "image_title": image_alt,
+    #         "image_full": image_fullsize,
+    #         "source": urlparse(link).netloc,
+    #     })
 
     # calc. time spent
     end_time = time.time()

--- a/static/css/catppuccin_mocha_blue.css
+++ b/static/css/catppuccin_mocha_blue.css
@@ -60,11 +60,6 @@
     box-shadow: 0 1px 3px rgba(0, 0, 0, 0.5);
 }
 
-.image {
-    box-shadow: 0 1px 3px rgba(0, 0, 0, 0.12), 0 1px 2px rgba(0, 0, 0, 0.24);
-    transition: all 0.3s cubic-bezier(.25, .8, .25, 1);
-}
-
 .view-image-search {
     box-shadow: 0 1px 3px rgba(0, 0, 0, 0.12), 0 1px 2px rgba(0, 0, 0, 0.24);
     transition: all 0.3s cubic-bezier(.25, .8, .25, 1);

--- a/static/css/catppuccin_mocha_green.css
+++ b/static/css/catppuccin_mocha_green.css
@@ -60,11 +60,6 @@
     box-shadow: 0 1px 3px rgba(0, 0, 0, 0.5);
 }
 
-.image {
-    box-shadow: 0 1px 3px rgba(0, 0, 0, 0.12), 0 1px 2px rgba(0, 0, 0, 0.24);
-    transition: all 0.3s cubic-bezier(.25, .8, .25, 1);
-}
-
 .view-image-search {
     box-shadow: 0 1px 3px rgba(0, 0, 0, 0.12), 0 1px 2px rgba(0, 0, 0, 0.24);
     transition: all 0.3s cubic-bezier(.25, .8, .25, 1);

--- a/static/css/classic.css
+++ b/static/css/classic.css
@@ -60,11 +60,6 @@
     box-shadow: 0 1px 3px rgba(0, 0, 0, 0.5);
 }
 
-.image {
-    box-shadow: 0 1px 3px rgba(0, 0, 0, 0.12), 0 1px 2px rgba(0, 0, 0, 0.24);
-    transition: all 0.3s cubic-bezier(.25, .8, .25, 1);
-}
-
 .view-image-search {
     box-shadow: 0 1px 3px rgba(0, 0, 0, 0.12), 0 1px 2px rgba(0, 0, 0, 0.24);
     transition: all 0.3s cubic-bezier(.25, .8, .25, 1);

--- a/static/css/dark.css
+++ b/static/css/dark.css
@@ -60,11 +60,6 @@
     box-shadow: 0 1px 3px rgba(0, 0, 0, 0.5);
 }
 
-.image {
-    box-shadow: 0 1px 3px rgba(0, 0, 0, 0.12), 0 1px 2px rgba(0, 0, 0, 0.24);
-    transition: all 0.3s cubic-bezier(.25, .8, .25, 1);
-}
-
 .view-image-search {
     box-shadow: 0 1px 3px rgba(0, 0, 0, 0.12), 0 1px 2px rgba(0, 0, 0, 0.24);
     transition: all 0.3s cubic-bezier(.25, .8, .25, 1);

--- a/static/css/dark_blur.css
+++ b/static/css/dark_blur.css
@@ -64,11 +64,6 @@
     box-shadow: 0 1px 3px rgba(0, 0, 0, 0.5);
 }
 
-.image {
-    box-shadow: 0 1px 3px rgba(0, 0, 0, 0.12), 0 1px 2px rgba(0, 0, 0, 0.24);
-    transition: all 0.3s cubic-bezier(.25, .8, .25, 1);
-}
-
 .view-image-search {
     box-shadow: 0 1px 3px rgba(0, 0, 0, 0.12), 0 1px 2px rgba(0, 0, 0, 0.24);
     transition: all 0.3s cubic-bezier(.25, .8, .25, 1);

--- a/static/css/dark_default.css
+++ b/static/css/dark_default.css
@@ -64,11 +64,6 @@
     box-shadow: 0 1px 3px rgba(0, 0, 0, 0.5);
 }
 
-.image {
-    box-shadow: 0 1px 3px rgba(0, 0, 0, 0.12), 0 1px 2px rgba(0, 0, 0, 0.24);
-    transition: all 0.3s cubic-bezier(.25, .8, .25, 1);
-}
-
 .view-image-search {
     box-shadow: 0 1px 3px rgba(0, 0, 0, 0.12), 0 1px 2px rgba(0, 0, 0, 0.24);
     transition: all 0.3s cubic-bezier(.25, .8, .25, 1);

--- a/static/css/darker.css
+++ b/static/css/darker.css
@@ -60,11 +60,6 @@
     box-shadow: 0 1px 3px rgba(0, 0, 0, 0.5);
 }
 
-.image {
-    box-shadow: 0 1px 3px rgba(0, 0, 0, 0.12), 0 1px 2px rgba(0, 0, 0, 0.24);
-    transition: all 0.3s cubic-bezier(.25, .8, .25, 1);
-}
-
 .view-image-search {
     box-shadow: 0 1px 3px rgba(0, 0, 0, 0.12), 0 1px 2px rgba(0, 0, 0, 0.24);
     transition: all 0.3s cubic-bezier(.25, .8, .25, 1);

--- a/static/css/gentoo_lavender.css
+++ b/static/css/gentoo_lavender.css
@@ -48,11 +48,6 @@
     color: var(--highlight) !important;
 }
 
-.image:hover {
-    box-shadow: 0px 2px 4px rgba(0, 0, 0, 0.08) !important;
-    transition: all 0.3s cubic-bezier(.25, .8, .25, 1) !important;
-}
-
 .image_view {
     box-shadow: 0px 2px 4px rgba(0, 0, 0, 0.08) !important;
     transition: all 0.3s cubic-bezier(.25, .8, .25, 1) !important;

--- a/static/css/github_night.css
+++ b/static/css/github_night.css
@@ -60,11 +60,6 @@
     box-shadow: 0 1px 3px rgba(0, 0, 0, 0.5);
 }
 
-.image {
-    box-shadow: 0 1px 3px rgba(0, 0, 0, 0.12), 0 1px 2px rgba(0, 0, 0, 0.24);
-    transition: all 0.3s cubic-bezier(.25, .8, .25, 1);
-}
-
 .view-image-search {
     box-shadow: 0 1px 3px rgba(0, 0, 0, 0.12), 0 1px 2px rgba(0, 0, 0, 0.24);
     transition: all 0.3s cubic-bezier(.25, .8, .25, 1);

--- a/static/css/light.css
+++ b/static/css/light.css
@@ -48,11 +48,6 @@
     color: var(--highlight) !important;
 }
 
-.image:hover {
-    box-shadow: 0px 2px 4px rgba(0, 0, 0, 0.08) !important;
-    transition: all 0.3s cubic-bezier(.25, .8, .25, 1) !important;
-}
-
 .image_view {
     box-shadow: 0px 2px 4px rgba(0, 0, 0, 0.08) !important;
     transition: all 0.3s cubic-bezier(.25, .8, .25, 1) !important;

--- a/static/css/night.css
+++ b/static/css/night.css
@@ -60,11 +60,6 @@
     box-shadow: 0 1px 3px rgba(0, 0, 0, 0.5);
 }
 
-.image {
-    box-shadow: 0 1px 3px rgba(0, 0, 0, 0.12), 0 1px 2px rgba(0, 0, 0, 0.24);
-    transition: all 0.3s cubic-bezier(.25, .8, .25, 1);
-}
-
 .view-image-search {
     box-shadow: 0 1px 3px rgba(0, 0, 0, 0.12), 0 1px 2px rgba(0, 0, 0, 0.24);
     transition: all 0.3s cubic-bezier(.25, .8, .25, 1);

--- a/static/css/red.css
+++ b/static/css/red.css
@@ -71,11 +71,6 @@
     box-shadow: 0 1px 3px rgba(0, 0, 0, 0.5);
 }
 
-.image {
-    box-shadow: 0 1px 3px rgba(0, 0, 0, 0.12), 0 1px 2px rgba(0, 0, 0, 0.24);
-    transition: all 0.3s cubic-bezier(.25, .8, .25, 1);
-}
-
 .view-image-search {
     box-shadow: 0 1px 3px rgba(0, 0, 0, 0.12), 0 1px 2px rgba(0, 0, 0, 0.24);
     transition: all 0.3s cubic-bezier(.25, .8, .25, 1);

--- a/static/css/style.css
+++ b/static/css/style.css
@@ -234,36 +234,85 @@ html {
 }
 
 .images {
-    display: flex;
-    flex-wrap: wrap;
-    grid-gap: 1.2rem;
-    justify-content: center;
-    margin-left: 1.2%;
-    margin-right: 35.4%;
-    padding: 0;
-    margin-bottom: 50px;
+  margin: 0;
+  display: flex;
+  flex-wrap: wrap;
+  margin-right: 35.4%;
+  position: relative;
 }
 
 .image {
-    flex-grow: 1;
-    height: 10rem;
-    margin: 0;
-    overflow: hidden;
-    border-radius: 10px;
-    border: 1px solid var(--border);
+  flex-grow: 1;
+  padding: .5rem .5rem 3rem .5rem;
+  margin: .25rem;
+  border: 1px solid #00000000;
+  border-radius: 12px;
+  height: 10rem;
 }
 
-.image:hover {
+.image_selected {
+  border-color: var(--blue);
+}
+
+.image > a {
+  position: relative;
+  text-decoration: none;
+}
+
+.image .resolution {
+  position: absolute;
+  opacity: 0;
+  top: calc(100% - 25px);
+  left: 5px; 
+  font-size: 12px;
+  background-color: #000000A0;
+  color: var(--fg);
+  border-radius: 4px;
+  height: 18px;
+  display: flex;
+  align-items: center;
+  transition: .3s;
+  padding: 0 2px;
+}
+
+.image:hover .resolution {
+  opacity: 1;
+}
+
+.image:hover img {
     box-shadow: 0 14px 28px rgba(0, 0, 0, 0.25), 0 10px 10px rgba(0, 0, 0, 0.22);
 }
 
+.img_title, .img_source {
+  display: block;
+  position: absolute;
+  width: 100%;
+  font-size: .9rem;
+  color: var(--fg);
+  padding: .5rem 0 0 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.img_title {
+  color: var(--blue);
+}
+
+.img_source {
+  padding: 1.8rem 0 0 0;
+  font-size: .7rem;
+}
+
 .image img {
-    margin: 0;
-    height: 100%;
-    width: 100%;
-    object-fit: cover;
-    object-position: center;
-    vertical-align: bottom;
+  margin: 0;
+  padding: 0;
+  border: none;
+  height: 100%;
+  width: 100%;
+  object-fit: cover;
+  vertical-align: bottom;
+  border-radius: 12px;
 }
 
 .image_view {

--- a/static/script.js
+++ b/static/script.js
@@ -181,10 +181,11 @@ if (urlParams.get("t") === "image") {
   const imageView = document.querySelector('.image_view');
   const images = document.querySelector('.images');
   const viewImageImg = document.querySelector('.view-image-img');
-  const proxyLinkUwu = document.querySelector('.proxy-link-uwu');
   const imageSource = document.querySelector('.image-source');
+  const imageFull = document.querySelector(".full-size");
   const imageViewerLink = document.querySelector('.image-viewer-link');
   const imageSize = document.querySelector('.image-size');
+  const fullImageSize = document.querySelector(".full-image-size");
   const imageAlt = document.querySelector('.image-alt');
   const openImageViewer = document.querySelectorAll('.open-image-viewer');
   const imageBefore = document.querySelector('.image-before');
@@ -194,6 +195,9 @@ if (urlParams.get("t") === "image") {
   closeButton.addEventListener('click', function() {
     imageView.classList.remove('image_show');
     imageView.classList.add('image_hide');
+    for (const image of document.querySelectorAll(".image_selected")) {
+      image.classList = ['image'];
+    }
     images.classList.add('images_viewer_hidden');
   });
 
@@ -230,20 +234,25 @@ if (urlParams.get("t") === "image") {
   });
 
   function showImage() {
+    for (const image of document.querySelectorAll(".image_selected")) {
+      image.classList = ['image'];
+    }
+    document.querySelectorAll(".image")[currentImageIndex].classList.add("image_selected") ;
     const src = openImageViewer[currentImageIndex].getAttribute('src');
     const alt = openImageViewer[currentImageIndex].getAttribute('alt');
     const data = openImageViewer[currentImageIndex].getAttribute('data');
     const clickableLink = openImageViewer[currentImageIndex].closest('.clickable');
     const href = clickableLink.getAttribute('href');
     viewImageImg.src = src;
-    proxyLinkUwu.href = data;
+    imageFull.href = data;
     imageSource.href = href;
-    imageViewerLink.href = href;
     imageSource.textContent = href;
+    imageViewerLink.href = href;
     images.classList.remove('images_viewer_hidden');
     imageView.classList.remove('image_hide');
     imageView.classList.add('image_show');
     imageAlt.textContent = alt;
+    fullImageSize.textContent = document.querySelector(".image_selected .resolution").textContent;
 
     getImageSize(src).then(size => {
       imageSize.textContent = size;

--- a/templates/images.html
+++ b/templates/images.html
@@ -17,16 +17,27 @@
             </a>
             <p class="image-alt"></p>
             <p>View source: <a class="image-source" href=""></a></p>
-            <p>View full resolution image with <a class="proxy-link-uwu" href="">proxy</a></p>
+            <p>View full resolution image: <a class="full-size" href="">full</a></p>
             <p>Engine: qwant image search</p>
             <hr>
             <p>Image proxy size: <span class="image-size"></span></p>
+            <p>Full image size: <span class="full-image-size"></span></p>
         </div>
         {% for result in results %}
-        <div class="image">
-        <a class="clickable" {% if settings.new_tab == "active" %} target="_blank" {% endif %} href="{{ result[1] }}">
-            <img class="open-image-viewer" src="{{ result[0] }}" alt="{{ result[2] }}" data="{{ result[3] }}"/>
-        </a>
+        <div class="image" width="{{ result.thumb_height }}">
+          <a class="clickable" {% if settings.new_tab == "active" %} target="_blank" {% endif %} href="{{ result.url }}">
+              <img 
+                class="open-image-viewer"
+                src="{{ result.thumb_proxy }}"
+                alt="{{ result.title }}"
+                data="{{ result.media }}"
+              />
+              <div class="resolution">{{ result.width }} × {{ result.height }}</div>
+              <div class="details">
+                <div class="img_title">{{ result.title }}</div>
+                <div class="img_source">{{ result.source }}</div>
+              </div>
+          </a>
         </div>
         {% endfor %}
     </div>


### PR DESCRIPTION
This PR does a few things to improve the image page.
It simplifies the images.py and images.html code, so that it's a lot more easier to read.
It adds a title and domain to all of the images.
It adds a box around the selected image.
And it adds a box in the bottom left showing the resolution of the original image.
It also shows the a link to the full size image in when you open the image menu.

These changes are mainly based on qwant's image page, since I think that looks quite good.