### PR TITLE
Improve proxy speed

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -128,7 +128,7 @@ def img_proxy():
 
     # Only allow proxying image from qwant.com,
     # upload.wikimedia.org, and the default invidious instance
-    if not url.startswith(("https://s1.qwant.com/", "https://s2.qwant.com/",
+    if not url.startswith(("https://tse.mm.bing.net/",
                            "https://upload.wikimedia.org/wikipedia/commons/",
                            f"https://{INVIDIOUS_INSTANCE}")
                           ):

--- a/src/images.py
+++ b/src/images.py
@@ -46,7 +46,10 @@ def imageResults(query) -> Response:
 
     results = []
     for image in images:
-        image['thumb_proxy'] = f"/img_proxy?url={quote(image['thumbnail'])}"
+        # Get original bing image URL
+        bing_url = unquote(urlparse(image['thumbnail']).query).split("u=")[1].split("&")[0]
+
+        image['thumb_proxy'] = f"/img_proxy?url={quote(bing_url)}"
 
         # Get domain name
         image['source'] = urlparse(image['url']).netloc


### PR DESCRIPTION
Qwant gets their images from bing, then proxies it themselves.
This PR removes qwant's proxy, so instead of going

     bing -> qwant -> araa -> user

it goes

    bing -> araa -> user

Which decreases the time taken to proxy the image.