### PR TITLE
Make it easier to add new languages

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -50,8 +50,8 @@ def settings():
         lang_data = json.load(file)
 
     # Upgrade the request URL to https as to prevent a redirection error with /save-settings.
-    # if not request.is_secure:
-    #     request.url = f"https://{request.host}/settings{f'?{request.query_string.decode()}' if request.query_string.decode() else ''}"
+    if not request.is_secure:
+        request.url = f"https://{request.host}/settings{f'?{request.query_string.decode()}' if request.query_string.decode() else ''}"
 
     return render_template('settings.html',
                            commit=COMMIT,

--- a/__init__.py
+++ b/__init__.py
@@ -39,6 +39,7 @@ invidious = requests.Session() # invidious
 ac.headers.update({'User-Agent': 'Mozilla/5.0 (Macintosh; Intel Mac OS X 14.1; rv:109.0) Gecko/20100101 Firefox/121.0"'})
 googleac.headers.update({'User-Agent': 'Mozilla/5.0 (Macintosh; Intel Mac OS X 14.1; rv:109.0) Gecko/20100101 Firefox/121.0"'})
 
+
 @app.route('/settings')
 def settings():
     settings = helpers.Settings()
@@ -49,8 +50,8 @@ def settings():
         lang_data = json.load(file)
 
     # Upgrade the request URL to https as to prevent a redirection error with /save-settings.
-    if not request.is_secure:
-        request.url = f"https://{request.host}/settings{f'?{request.query_string.decode()}' if request.query_string.decode() else ''}"
+    # if not request.is_secure:
+    #     request.url = f"https://{request.host}/settings{f'?{request.query_string.decode()}' if request.query_string.decode() else ''}"
 
     return render_template('settings.html',
                            commit=COMMIT,
@@ -59,8 +60,10 @@ def settings():
                            current_url=request.url,
                            API_ENABLED=API_ENABLED,
                            settings=settings,
-                           lang_data=lang_data
+                           lang_data=lang_data,
+                           UX_LANGUAGES=UX_LANGUAGES
                            )
+
 
 @app.route('/discover')
 def discover():

--- a/_config.py
+++ b/_config.py
@@ -107,3 +107,31 @@ CAPTCHA_ENABLED = False
 
 # 2captcha api key
 CAPTCHA_API_KEY = "YOUR_API_KEY"
+
+UX_LANGUAGES = [
+    {'lang_lower': 'english', 'lang_fancy': 'English'},
+    {'lang_lower': 'danish', 'lang_fancy': 'Danish (Dansk)'},
+    {'lang_lower': 'dutch', 'lang_fancy': 'Dutch (Nederlands)'},
+    {'lang_lower': 'french', 'lang_fancy': 'French (Français)'},
+    {'lang_lower': 'french_canadian', 'lang_fancy': 'French Canadian (Français canadien)'},
+    {'lang_lower': 'german', 'lang_fancy': 'German (Deutsch)'},
+    {'lang_lower': 'greek', 'lang_fancy': 'Greek (Ελληνικά)'},
+    {'lang_lower': 'italian', 'lang_fancy': 'Italian (Italiano)'},
+    {'lang_lower': 'japanese', 'lang_fancy': 'Japanese (日本語)'},
+    {'lang_lower': 'korean', 'lang_fancy': 'Korean (한국어)'},
+    {'lang_lower': 'mandarin_chinese', 'lang_fancy': 'Mandarin Chinese (普通话 or 中文)'},
+    {'lang_lower': 'norwegian', 'lang_fancy': 'Norwegian (Norsk)'},
+    {'lang_lower': 'polish', 'lang_fancy': 'Polish (Polski)'},
+    {'lang_lower': 'portuguese', 'lang_fancy': 'Portuguese (Português)'},
+    {'lang_lower': 'russian', 'lang_fancy': 'Russian (Русский)'},
+    {'lang_lower': 'spanish', 'lang_fancy': 'Spanish (Español)'},
+    {'lang_lower': 'swedish', 'lang_fancy': 'Swedish (Svenska)'},
+    {'lang_lower': 'turkish', 'lang_fancy': 'Turkish (Türkçe)'},
+    {'lang_lower': 'ukrainian', 'lang_fancy': 'Ukrainian (Українська)'},
+    {'lang_lower': 'romanian', 'lang_fancy': 'Romanian (Română)'},
+]
+
+# See all the 'lang_lower' values in UX_LANGUAGES
+DEFAULT_UX_LANG = "english"
+
+DEFAULT_GOOGLE_DOMAIN = "/search?gl=us"

--- a/src/helpers.py
+++ b/src/helpers.py
@@ -256,12 +256,12 @@ def bytes_to_string(size):
 
 class Settings():
     def __init__(self):
-        self.domain = request.cookies.get("domain", "/search?gl=us")
+        self.domain = request.cookies.get("domain", DEFAULT_GOOGLE_DOMAIN)
         self.javascript = request.cookies.get("javascript", "enabled")
         self.lang = request.cookies.get("lang", "")
         self.new_tab = request.cookies.get("new_tab", "")
         self.safe = request.cookies.get("safe", "active")
-        self.ux_lang = request.cookies.get("ux_lang", "english")
+        self.ux_lang = request.cookies.get("ux_lang", DEFAULT_UX_LANG)
         self.theme = request.cookies.get("theme", DEFAULT_THEME)
         self.method = request.cookies.get("method", DEFAULT_METHOD)
         self.ac = request.cookies.get("ac", DEFAULT_AUTOCOMPLETE)

--- a/static/lang/README.md
+++ b/static/lang/README.md
@@ -1,0 +1,10 @@
+The file should be saved to a file in `static/lang/` and should be titled with the english name of the language in all lower case, followed by '.json'.
+
+Make sure to add an entry to `UX_LANGUAGES` in _config.py
+
+It should be formatted like this:
+
+    {'lang_lower': 'french', 'lang_fancy': 'French (Français)'},
+
+`lang_lower` should match the first part of the json file (e.g. 'english' for 'english.json').
+`lang_fancy` should be the name of the language in english with the first letter capitalized, followed by the name of the language in its own language in brackets.

--- a/templates/settings.html
+++ b/templates/settings.html
@@ -76,26 +76,10 @@
         <div class="settings-row">
         <p>{{ lang_data.settings.preferredux_language }}</p>
         <select id="ux_lang" name="ux_lang">
-            <option value="english" {% if settings.ux_lang == 'english' %}selected{% endif %}>English</option>
-            <option value="danish" {% if settings.ux_lang == 'danish' %}selected{% endif %}>Danish (Dansk)</option>
-            <option value="dutch" {% if settings.ux_lang == 'dutch' %}selected{% endif %}>Dutch (Nederlands)</option>
-            <option value="french" {% if settings.ux_lang == 'french' %}selected{% endif %}>French (Français)</option>
-            <option value="french_canadian" {% if settings.ux_lang == 'french_canadian' %}selected{% endif %}>French Canadian (Français canadien)</option>
-            <option value="german" {% if settings.ux_lang == 'german' %}selected{% endif %}>German (Deutsch)</option>
-            <option value="greek" {% if settings.ux_lang == 'greek' %}selected{% endif %}>Greek (Ελληνικά)</option>
-            <option value="italian" {% if settings.ux_lang == 'italian' %}selected{% endif %}>Italian (Italiano)</option>
-            <option value="japanese" {% if settings.ux_lang == 'japanese' %}selected{% endif %}>Japanese (日本語)</option>
-            <option value="korean" {% if settings.ux_lang == 'korean' %}selected{% endif %}>Korean (한국어)</option>
-            <option value="mandarin_chinese" {% if settings.ux_lang == 'mandarin_chinese' %}selected{% endif %}>Mandarin Chinese (普通话 or 中文)</option>
-            <option value="norwegian" {% if settings.ux_lang == 'norwegian' %}selected{% endif %}>Norwegian (Norsk)</option>
-            <option value="polish" {% if settings.ux_lang == 'polish' %}selected{% endif %}>Polish (Polski)</option>
-            <option value="portuguese" {% if settings.ux_lang == 'portuguese' %}selected{% endif %}>Portuguese (Português)</option>
-            <option value="russian" {% if settings.ux_lang == 'russian' %}selected{% endif %}>Russian (Русский)</option>
-            <option value="spanish" {% if settings.ux_lang == 'spanish' %}selected{% endif %}>Spanish (Español)</option>
-            <option value="swedish" {% if settings.ux_lang == 'swedish' %}selected{% endif %}>Swedish (Svenska)</option>
-            <option value="turkish" {% if settings.ux_lang == 'turkish' %}selected{% endif %}>Turkish (Türkçe)</option>
-            <option value="ukrainian" {% if settings.ux_lang == 'ukrainian' %}selected{% endif %}>Ukrainian (Українська)</option>
-        </select>            
+            {% for language in UX_LANGUAGES %}
+              <option value="{{ language.lang_lower }}" {% if settings.ux_lang == language.lang_lower %}selected{% endif %}>{{ language.lang_fancy }}</option>
+            {% endfor %}
+        </select>
         </div>
     <div class="settings-row">
         <p>{{ lang_data.settings.google_domain }}</p>


### PR DESCRIPTION
This adds a constant in _config.py, where you can easily add text for displaying the language in the settings page.

In both #88 and #118, the contributors forgot to add it to the settings.html file. This PR will probably make it easier to do so for people who haven't got knowledge in html, or otherwise didn't think to add it.

I've also added a readme file with some instructions, which might help people who add languages in the future.