### PR TITLE
Add caching.

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -268,5 +268,12 @@ def search():
             return textResults.textResults(query)
 
 
+@app.after_request
+def add_header(response):
+    # Let browser refresh cached data once every hour.
+    response.cache_control.max_age = 3600
+    return response
+
+
 if __name__ == "__main__":
     app.run(threaded=True, port=PORT)


### PR DESCRIPTION
When you refresh araa, the browser grabs everything (such as fonts, and css files).
This PR changes it so that the browser will only request the data once every hour.
I've chosen once an hour to allow for changes to the files.

This will make the experience with switching search types a lot nicer, and also decrease server load.