### PR TITLE
Add clear search button and show suggestions on input focus

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -111,6 +111,7 @@ def suggestions():
         query = request.args.get("q", "").strip()
     else:
         query = request.form.get("q", "").strip()
+
     if settings.ac == "ddg":
         response = ac.get(f"https://ac.duckduckgo.com/ac?q={quote(query)}&type=list")
         return json.loads(response.text)

--- a/static/css/style.css
+++ b/static/css/style.css
@@ -69,7 +69,8 @@
     -moz-osx-font-smoothing: grayscale;
 }
 
-#search-wrapper-ico, #clearSearch {
+#search-wrapper-ico,
+#clearSearch {
     background: none;
     border: none;
     color: var(--fg);
@@ -79,8 +80,9 @@
     cursor: pointer;
 }
 
-#search-wrapper-ico:hover, #clearSearch:hover {
-  color: var(--blue);
+#search-wrapper-ico:hover,
+#clearSearch:hover {
+    color: var(--blue);
 }
 
 #sub-search-wrapper-ico {
@@ -94,8 +96,8 @@
 }
 
 #clearSearch {
-  right: 40px;
-  visibility: hidden;
+    right: 40px;
+    visibility: hidden;
 }
 
 .fetched_dif {
@@ -1661,5 +1663,9 @@ p {
         display: table-row;
         margin: 30px 0px 0px 0px;
         width: 80%;
+    }
+
+    #clearSearch {
+        top: 6px;
     }
 }

--- a/static/css/style.css
+++ b/static/css/style.css
@@ -82,6 +82,7 @@
 
 #search-wrapper-ico:hover,
 #clearSearch:hover {
+    transition: all .3s ease;
     color: var(--blue);
 }
 

--- a/static/css/style.css
+++ b/static/css/style.css
@@ -69,14 +69,18 @@
     -moz-osx-font-smoothing: grayscale;
 }
 
-#search-wrapper-ico {
+#search-wrapper-ico, #clearSearch {
     background: none;
     border: none;
-    color: var(--blue);
+    color: var(--fg);
     position: absolute;
-    top: 6px;
+    top: 7px;
     right: 10px;
     cursor: pointer;
+}
+
+#search-wrapper-ico:hover, #clearSearch:hover {
+  color: var(--blue);
 }
 
 #sub-search-wrapper-ico {
@@ -87,6 +91,11 @@
     /* will be set to 17px if icon pack can be loaded. */
     padding-right: 0px;
     margin-right: 0px;
+}
+
+#clearSearch {
+  right: 40px;
+  visibility: hidden;
 }
 
 .fetched_dif {

--- a/static/script.js
+++ b/static/script.js
@@ -63,9 +63,9 @@ searchInput.addEventListener('input', async () => {
 });
 
 searchInput.addEventListener("focus", async () => {
-  if (results.length === 0) {
-    console.log("dfsakjfkds")
-    results = await getSuggestions(searchInput.value);
+  let input = searchInput.value;
+  if (results.length === 0 && input.length != 0) {
+    results = await getSuggestions(input);
   }
   renderResults(results);
 })

--- a/static/script.js
+++ b/static/script.js
@@ -37,6 +37,7 @@ if (resultsSave != null) {
 const searchInput = document.getElementById('search-input');
 const searchWrapper = document.querySelectorAll('.wrapper, .wrapper-results')[0];
 const resultsWrapper = document.querySelector('.autocomplete');
+const clearSearch = document.querySelector("#clearSearch");
 
 async function getSuggestions(query) {
   try {
@@ -51,8 +52,8 @@ async function getSuggestions(query) {
 
 let currentIndex = -1; // Keep track of the currently selected suggestion
 
+let results = [];
 searchInput.addEventListener('input', async () => {
-  let results = [];
   let input = searchInput.value;
   if (input.length) {
     results = await getSuggestions(input);
@@ -60,6 +61,20 @@ searchInput.addEventListener('input', async () => {
   renderResults(results);
   currentIndex = -1; // Reset index when we return new results
 });
+
+searchInput.addEventListener("focus", async () => {
+  if (results.length === 0) {
+    console.log("dfsakjfkds")
+    results = await getSuggestions(searchInput.value);
+  }
+  renderResults(results);
+})
+
+clearSearch.style.visibility = "visible"; // Only show the clear search button for JS users.
+clearSearch.addEventListener("click", () => {
+  searchInput.value = "";
+  searchInput.focus();
+})
 
 searchInput.addEventListener('keydown', (event) => {
   if (event.key === 'ArrowUp' || event.key === 'ArrowDown') {

--- a/templates/results_layout.html
+++ b/templates/results_layout.html
@@ -104,6 +104,7 @@
         <div class="wrapper-results">
         <input type="text" name="q" value="{{ q }}" id="search-input" />
         <button id="search-wrapper-ico" class="material-icons-round" name="t" value="{{ type }}">search</button>
+        <a id="clearSearch" class="material-icons-round">close</a>
         <input type="submit" class="hide" name="t" value="{{ type }}" />
         <div class="autocomplete">
             <ul>

--- a/templates/search.html
+++ b/templates/search.html
@@ -88,7 +88,8 @@
         <div class="wrapper">
             <input type="text" name="q" autofocus id="search-input" />
             <button id="search-wrapper-ico" class="material-icons-round" name="t" value="text" type="submit">search</button>
-            <input type="submit" class="hide" />
+            <a id="clearSearch" class="material-icons-round">close</a>
+            <input type="submit" class="hide"/>
             <div class="autocomplete">
                 <ul>
                 </ul>


### PR DESCRIPTION
This adds a button in the search input field that lets you clear the results. It only shows for JS users because there's no way to clear an input without JS.

This also makes clicking on the search field automatically show the suggestions.