### PR TITLE
Stop googles extra text from showing in the snippet

### DIFF
--- a/src/textResults.py
+++ b/src/textResults.py
@@ -102,6 +102,9 @@ def textResults(query) -> Response:
         else:
             rkno_title = ""
 
+    for div in soup.find_all("div", {'class': 'nnFGuf'}): 
+        div.decompose()
+
     # retrieve featured snippet
     try:
         featured_snip = soup.find("span", {"class": "hgKElc"})


### PR DESCRIPTION
On google, in the snippets, you can usually click on words/names to get more info on it. This is included when you run `snip = featured_snip.text.strip()`.
This PR removes those elements, so they don't come up in the results.

Before:
![maccabees-1](https://github.com/Extravi/araa-search/assets/83502633/909907c8-b40a-4251-a323-12680178f96c)

After:
![maccabees-2](https://github.com/Extravi/araa-search/assets/83502633/1089ecd0-047a-4902-b2a6-22af4f25fa02)