### PR TITLE
Remove empty results div under first result.

### DIFF
--- a/src/textResults.py
+++ b/src/textResults.py
@@ -5,7 +5,7 @@ from flask import request, render_template, jsonify, Response
 import time
 import json
 import re
-from math import isclose # For float comparisons
+from math import isclose  # For float comparisons
 
 
 def textResults(query) -> Response:

--- a/static/css/style.css
+++ b/static/css/style.css
@@ -111,6 +111,7 @@
 }
 
 .clean {
+    margin-top: 30px;
     max-width: 775px;
 }
 

--- a/templates/results.html
+++ b/templates/results.html
@@ -133,15 +133,14 @@
         <p>{{ results[0][2]|highlight_query_words(q) }}</p>
     </div>
     {% endif %}
-    {% if sublink == "" %}
-    {% else %}
+    {% if sublink %}
     <div class="results">
-    {% for result in sublink %}
-    <div class="sublinks">
-        <a href="{{ result[0] }}" {% if settings.new_tab == "active"  %} target="_blank" {% endif %}><h3>{{ result[1] }}</h3></a>
-        <p>{{ result[2] }}</p>
-    </div>
-    {% endfor %}
+      {% for result in sublink %}
+      <div class="sublinks">
+          <a href="{{ result[0] }}" {% if settings.new_tab == "active"  %} target="_blank" {% endif %}><h3>{{ result[1] }}</h3></a>
+          <p>{{ result[2] }}</p>
+      </div>
+      {% endfor %}
     </div>
     {% endif %}
     {% if results %}


### PR DESCRIPTION
If you use a theme like the windows 95 theme from the discover themes section in settings, there's always an empty box under the first result. It's there for the sublinks, but when sublinks aren't there, it's not needed.
This PR removes that div, unless it's needed.