### PR TITLE
Dont refresh after changing the theme

### DIFF
--- a/static/cookies.js
+++ b/static/cookies.js
@@ -30,14 +30,6 @@ function setCookie(name, value) {
     document.cookie = `${name}=${value}; HostOnly=true; SameSite=None; Secure; Max-Age=2147483647`;
 }
 
-function reloadPageForTheme() {
-    const themeCookie = document.cookie.split(";").find((cookie) => cookie.trim().startsWith("theme="));
-
-    if (themeCookie) {
-        window.location.reload();
-    }
-}
-
 document.addEventListener("DOMContentLoaded", function () {
     const langSelect = document.querySelector(".lang");
 
@@ -67,7 +59,11 @@ document.addEventListener("DOMContentLoaded", function () {
         div.addEventListener("click", function () {
             const clickedDivId = div.firstElementChild.id;
             setCookie("theme", clickedDivId);
-            reloadPageForTheme();
+            for (const link of document.querySelectorAll('link[rel="stylesheet"]')) {
+              if (!link['href'].includes("style")) {
+                link['href'] = `./css/${clickedDivId}.css`
+              }
+            }
         });
     });
 


### PR DESCRIPTION
When changing the theme, the entire page shouldn't reload.
This PR makes it so that instead of reloading the whole page when a different theme is selected, only the `link` element which holds the theme's location is changed.
This makes for a smoother, and more efficient way to change theme.