### PR TITLE
Dont change image when input is focused

### DIFF
--- a/static/script.js
+++ b/static/script.js
@@ -227,6 +227,8 @@ if (document.querySelectorAll(".search-active")[1].getAttribute("value") === "im
   });
 
   document.addEventListener('keydown', function (event) {
+    if (searchInput == document.activeElement)
+      return;
     if (event.key === 'ArrowLeft') {
       currentImageIndex = (currentImageIndex - 1 + openImageViewer.length) % openImageViewer.length;
       showImage();


### PR DESCRIPTION
If you select an image, then use the arrow keys, the image changes.
This PR stops that from happening