### PR TITLE
Remove citations from wiki desc

### DIFF
--- a/src/text_engines/qwant.py
+++ b/src/text_engines/qwant.py
@@ -1,8 +1,15 @@
+import re
 from src.text_engines.objects.fullEngineResults import FullEngineResults
 from src.text_engines.objects.textResult import TextResult
 from src.text_engines.objects.wikiSnippet import WikiSnippet
-from urllib.parse import urlparse, urlencode, quote
+from urllib.parse import urlparse, urlencode
 from src import helpers
+
+
+def sanitize_wiki(desc):
+    desc = re.sub(r"\[\d{1,}\]", "", desc)
+    return desc
+
 
 # NOTE: Qwant engine made by amongusussy. Taken from https://github.com/Extravi/araa-search/pull/106
 # Slightly modified to adapt different text results engine.
@@ -76,7 +83,7 @@ def search(query: str, page: int, search_type: str, user_settings: helpers.Setti
 
             wiki = WikiSnippet(
                 title = result['title'],
-                desc = result['desc'],
+                desc = sanitize_wiki(result['desc']),
                 link = result['source'],
                 image = wiki_image,
                 wiki_thumb_proxy_link = wiki_proxy_link,


### PR DESCRIPTION
Qwant wiki descriptions have citation numbers in them:
![image](https://github.com/user-attachments/assets/d59036fe-2067-44e9-8384-4f9ab365e87a)
This PR removes them.