### PR TITLE
Fix updated wiki

### DIFF
--- a/src/text_engines/google.py
+++ b/src/text_engines/google.py
@@ -48,11 +48,11 @@ def search(query: str, page: int, search_type: str, user_settings: helpers.Setti
 
     # retrieve kno-rdesc
     try:
-        rdesc = soup.find("div", {"class": "kno-rdesc"})
-        span_element = rdesc.find("span")
-        kno = span_element.text
-        desc_link = rdesc.find("a")
+        rdesc = soup.find("div", {"class": "CYJS5e"})
+        span_element = rdesc.find("span", {"class": "QoPDcf"})
+        desc_link = rdesc.find("a", {"class": "y171A"})
         kno_link = desc_link.get("href")
+        kno = span_element.find("span").get_text()
     except:
         kno = ""
         kno_link = ""


### PR DESCRIPTION
Google has updated the wiki format, which causes there to be no wiki snippets.
![image](https://github.com/user-attachments/assets/2785e2b2-5528-4a69-ad46-b50dd1a424c5)
This PR just renames some classes to fix it.