### PR TITLE
Add engine filter option and date range for google

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -97,7 +97,7 @@ def discover():
 
 @app.route('/save-settings', methods=['POST'])
 def save_settings():
-    cookies = ['safe', 'javascript', 'domain', 'theme', 'lang', 'ux_lang', 'new_tab', 'method', 'ac']
+    cookies = ['safe', 'javascript', 'domain', 'theme', 'lang', 'ux_lang', 'new_tab', 'method', 'ac', "engine"]
 
     response = make_response(redirect(request.referrer))
     for cookie in cookies:
@@ -107,7 +107,12 @@ def save_settings():
                                 max_age=COOKIE_AGE, httponly=False,
                                 secure=app.config.get("HTTPS")
                                 )
+
     response.headers["Location"] = request.form.get('past')
+
+    # Disable https when running in a debug mode to avoid ssl errors
+    if __name__ == "__main__":
+        response.headers["Location"] = response.headers["Location"].replace("https", "http")
 
     return response
 

--- a/_config.py
+++ b/_config.py
@@ -12,6 +12,9 @@ BANG = '!'
 REPO = 'https://github.com/Extravi/araa-search'
 DONATE = 'https://github.com/sponsors/Extravi'
 
+DEFAULT_ENGINE = "google"
+
+
 # Default theme
 DEFAULT_THEME = 'dark_default'
 

--- a/src/helpers.py
+++ b/src/helpers.py
@@ -146,6 +146,7 @@ def bytes_to_string(size):
         index += 1
     return f"{size:.2f} {units[index]}"
 
+
 class Settings():
     def __init__(self):
         self.domain = request.cookies.get("domain", DEFAULT_GOOGLE_DOMAIN)
@@ -157,6 +158,8 @@ class Settings():
         self.theme = request.cookies.get("theme", DEFAULT_THEME)
         self.method = request.cookies.get("method", DEFAULT_METHOD)
         self.ac = request.cookies.get("ac", DEFAULT_AUTOCOMPLETE)
+        self.engine = request.cookies.get("engine", DEFAULT_ENGINE)
+
 
 # Returns a tuple of two ellements.
 # The first is the wikipedia proxy's URL (used to load an wiki page's image after page load),

--- a/src/textResults.py
+++ b/src/textResults.py
@@ -51,9 +51,18 @@ def textResults(query: str) -> Response:
     ratelimited = True # Used to determine if complete engine failure is due to a bug or due to
                        # the server getting completely ratelimited from every supported engine.
 
+    engine_list = []
+    for engine in ENGINES:
+        if engine.NAME == settings.engine:
+            # Put prefered engine at the top of the list
+            engine_list = [engine] + engine_list
+        else:
+            engine_list.append(engine)
+
+
     try:
-        for ENGINE in ENGINES:
-            if (t := ratelimited_timestamps.get(ENGINE.__name__)) != None and t + ENGINE_RATELIMIT_COOLDOWN_MINUTES * 60 >= time.time():
+        for ENGINE in engine_list:
+            if (t := ratelimited_timestamps.get(ENGINE.__name__)) is not None and t + ENGINE_RATELIMIT_COOLDOWN_MINUTES * 60 >= time.time():
                 # Current engine is ratelimited. Skip it.
                 continue
             results = ENGINE.search(query, p, search_type, settings)
@@ -138,5 +147,6 @@ def textResults(query: str) -> Response:
                                type=search_type, repo_url=REPO, donate_url=DONATE, commit=helpers.latest_commit(),
                                exported_math_expression=exported_math_expression, API_ENABLED=API_ENABLED,
                                TORRENTSEARCH_ENABLED=TORRENTSEARCH_ENABLED, lang_data=lang_data,
-                               settings=settings, wiki=results.wiki, araa_name=ARAA_NAME
+                               settings=settings, wiki=results.wiki, araa_name=ARAA_NAME,
+                               before=args.get("before", ""), after=args.get("after", "")
                                )

--- a/src/text_engines/google.py
+++ b/src/text_engines/google.py
@@ -4,6 +4,10 @@ from _config import *
 from src.text_engines.objects.fullEngineResults import FullEngineResults
 from src.text_engines.objects.wikiSnippet import WikiSnippet
 from src.text_engines.objects.textResult import TextResult
+from flask import request
+
+
+NAME = "google"
 
 
 def __local_href__(url):
@@ -16,6 +20,13 @@ def __local_href__(url):
 def search(query: str, page: int, search_type: str, user_settings: helpers.Settings) -> FullEngineResults:
     if search_type == "reddit":
         query += " site:reddit.com"
+
+    after_date = request.args.get("after", "")
+    before_date = request.args.get("before", "")
+    if after_date != "":
+        query += f" after:{after_date}"
+    if before_date != "":
+        query += f" before:{before_date}"
 
     # Random characters are to trick google into thinking it's a mobile phone
     # loading more results

--- a/src/text_engines/qwant.py
+++ b/src/text_engines/qwant.py
@@ -5,6 +5,8 @@ from src.text_engines.objects.wikiSnippet import WikiSnippet
 from urllib.parse import urlparse, urlencode, unquote
 from src import helpers
 
+NAME = "qwant"
+
 
 def sanitize_wiki(desc):
     desc = re.sub(r"\[\d{1,}\]", "", desc)

--- a/static/cookies.js
+++ b/static/cookies.js
@@ -61,6 +61,16 @@ document.addEventListener("DOMContentLoaded", function () {
         });
     }
 
+    const engineSelect = document.querySelector("#engine_select")
+    if (engineSelect) {
+        engineSelect.addEventListener("change", function () {
+            const selectedOption = engineSelect.options[engineSelect.selectedIndex];
+            const selectedValue = selectedOption.value;
+            setCookie("engine", selectedValue);
+            window.location.reload();
+        });
+    }
+
     const themeDivs = document.querySelectorAll(".themes-settings-menu div");
 
     themeDivs.forEach(function (div) {

--- a/static/css/style.css
+++ b/static/css/style.css
@@ -571,6 +571,7 @@ hr {
 #lang,
 #safe,
 #open-new-tab,
+#engine,
 #domain,
 #javascript-setting,
 #ux_lang {
@@ -680,18 +681,23 @@ hr {
 }
 
 .results_settings {
+  margin-top: 110px;
+}
+
+.results_settings,
+#date_range_form {
     color: var(--fg);
     left: 175px;
     position: relative;
     font-size: 15px;
-    margin-bottom: 10px;
     max-width: 580px;
-    margin-top: 110px;
     display: flex;
 }
 
+
 .results-settings,
 .results-save,
+.date-select,
 .torrent-settings,
 .torrent-sort-save,
 .torrent-cat {
@@ -706,6 +712,25 @@ hr {
     cursor: pointer;
     transition: all .3s ease;
 }
+
+#date_range_form .results-settings {
+  text-align: left;
+}
+
+.date_range {
+  display: inherit;
+}
+
+.date_range p {
+  width: 80px;
+  margin: 4px;
+}
+
+.date-select {
+  height: 20px;
+  display: inline;
+}
+
 
 .torrent-cat:hover,
 .torrent-settings:hover,
@@ -1656,6 +1681,17 @@ p {
         font-size: 13px;
         margin-top: 140px;
         max-width: 355px;
+    }
+    
+    #date_range_form {
+      left: 20px;
+      max-width: 335px;
+    }
+    .date_range p {
+      display: none;
+    }
+    .date-select {
+      margin-right: 0px;
     }
 
     .video_title {

--- a/static/script.js
+++ b/static/script.js
@@ -29,7 +29,7 @@
 // Removes the 'Apply Settings' button for Javascript users, 
 // since changing any of the elements causes the settings to apply
 // automatically.
-let resultsSave = document.querySelector(".results-save");
+const resultsSave = document.querySelector(".results-save");
 if (resultsSave != null) {
   resultsSave.style.display = "none";
 }

--- a/templates/results.html
+++ b/templates/results.html
@@ -3,6 +3,10 @@
 {% block body %}
     <form class="results_settings" action="/save-settings" method="post">
       <input type="hidden" name="past" value="{{ current_url }}"></input>
+      <select class="results-settings" name="engine" id="engine_select">
+          <option value="google" {% if settings.engine == 'google' %}selected{% endif %}>Google</option>
+          <option value="qwant" {% if settings.engine == 'qwant' %}selected{% endif %}>Qwant</option>
+      </select>
       <select class="results-settings" name="safe" id="safeSearchSelect">
           <option value="active" {% if settings.safe == 'active' %}selected{% endif %}>{{ lang_data.settings.safe_search }} {{ lang_data.settings.on }}</option>
           <option value="" {% if settings.safe == '' %}selected{% endif %}>{{ lang_data.settings.safe_search }} {{ lang_data.settings.off }}</option>
@@ -58,7 +62,19 @@
       </select>
       <button class="results-save" type="submit">Apply settings</button>
     </form>
-    <p class="engine">Engine: {{ engine }}</p>
+
+    {% if engine != "qwant" %}
+      <form action="/search" id="date_range_form">
+        <input type="hidden" name="q" value="{{ q }}">
+        <input type="hidden" name="t" value="{{ type }}">
+        <div class="date_range">
+          <p>Date range</p>
+          <input class="date-select" type="date" name="after" value="{{ after }}">
+          <input class="date-select" type="date" name="before" value="{{ before }}">
+        </div>
+        <input type="submit" class="results-settings" value="Submit">
+      </form>
+    {% endif %}
     <p class="fetched">{{ lang_data.results.results }} {{ fetched }} {{ lang_data.results.seconds }}</p>
     {% if check %}
         <div class="check"><p>Did you mean: <a href="/search?q={{ check }}&t={{ type }}"><h3>{{ check }}</h3></a></p></div>

--- a/templates/settings.html
+++ b/templates/settings.html
@@ -111,6 +111,13 @@
         </select>
     </div>
     <div class="settings-row">
+        <p>Prefered search engine</p>
+        <select id="engine" name="engine">
+            <option value="google" {% if settings.engine == 'google' %}selected{% endif %}>Google</option>
+            <option value="qwant" {% if settings.engine == 'qwant' %}selected{% endif %}>Qwant</option>
+        </select>
+    </div>
+    <div class="settings-row">
         <p>Method</p>
         <select id="open-new-tab" name="method">
             <option value="GET" {% if settings.method == "GET" %}selected{% endif %}>GET</option>


### PR DESCRIPTION
This adds an option to change between either qwant or google. This will be quite useful for in the future if we decide to add any more engines.
It also adds a date filtering option, which closes #174.

![1737673064](https://github.com/user-attachments/assets/2de99f11-27bc-496b-855b-1796a6aa5c91)